### PR TITLE
DHL Parcel update to v1.2.7

### DIFF
--- a/pr-dhl-woocommerce/dhlpwoocommerce/README.md
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/README.md
@@ -1,5 +1,14 @@
 # DHL Parcel plugin for WooCommerce
 
+V1.2.7
+
+## Changes
+- Updated the ServicePoint locator to load from DHL's own servers instead of third party
+- Updated the ServicePoint locator to select the closest ServicePoint automatically
+- Added developer filters for price manipulation
+- Fixed delivery times API call to not send data when no postal code is set
+- Fixed tax adjustment calculation
+
 V1.2.6
 
 ## Changes

--- a/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
@@ -4,7 +4,7 @@ Plugin Name: DHL Parcel for WooCommmerce
 Plugin URI: https://www.dhlparcel.nl
 Description: This is the official DHL Parcel for WooCommerce plugin.
 Author: DHL Parcel
-Version: 1.2.6
+Version: 1.2.7
 WC requires at least: 3.0.0
 WC tested up to: 3.5.3
 */

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/admin/class-dhlpwc-controller-admin-order.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/admin/class-dhlpwc-controller-admin-order.php
@@ -24,7 +24,7 @@ class DHLPWC_Controller_Admin_Order
             if ($bulk_options = $service->check(DHLPWC_Model_Service_Access_Control::ACCESS_BULK_CREATE)) {
                 add_filter('bulk_actions-edit-shop_order', array($this, 'add_bulk_create_actions'));
                 foreach ($bulk_options as $bulk_option) {
-                    add_action('admin_action_dhlpwc_create_labels_'.$bulk_option, array($this, 'create_multiple_labels_'.$bulk_option));
+                    add_action('admin_action_dhlpwc_create_labels_' . $bulk_option, array($this, 'create_multiple_labels_' . $bulk_option));
                 }
                 add_action('admin_notices', array($this, 'bulk_create_notice'));
             }
@@ -59,7 +59,7 @@ class DHLPWC_Controller_Admin_Order
             '<a href="'.admin_url('edit.php?post_type=shop_order&orderby=dhlpwc_delivery_date&order=asc').'">',
             esc_attr(__('Delivery date', 'dhlpwc')),
             '</a>',
-            '<span class="count">('.$result->found_posts.')</span>');
+            '<span class="count">(' . $result->found_posts . ')</span>');
 
         return $views;
     }
@@ -143,7 +143,7 @@ class DHLPWC_Controller_Admin_Order
         $bulk_options = $service->check(DHLPWC_Model_Service_Access_Control::ACCESS_BULK_CREATE);
         foreach ($bulk_options as $bulk_option) {
             $bulk_string = 'BULK_'.strtoupper($bulk_option);
-            $bulk_actions['dhlpwc_create_labels_'.$bulk_option] = sprintf(__('DHL - Create label (%s)', 'dhlpwc'), __($bulk_string, 'dhlpwc'));
+            $bulk_actions['dhlpwc_create_labels_' . $bulk_option] = sprintf(__('DHL - Create label (%s)', 'dhlpwc'), __($bulk_string, 'dhlpwc'));
         }
         return $bulk_actions;
     }

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/class-dhlpwc-controller-checkout.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/class-dhlpwc-controller-checkout.php
@@ -53,7 +53,7 @@ class DHLPWC_Controller_Checkout
         foreach($presets as $preset_data) {
             $preset = new DHLPWC_Model_Meta_Shipping_Preset($preset_data);
 
-            if (isset($data['shipping_method']) && is_array($data['shipping_method']) && in_array('dhlpwc-'.$preset->frontend_id, $data['shipping_method'])) {
+            if (isset($data['shipping_method']) && is_array($data['shipping_method']) && in_array('dhlpwc-' . $preset->frontend_id, $data['shipping_method'])) {
                 $meta_service = new DHLPWC_Model_Service_Order_Meta_Option();
 
                 // Save preset data
@@ -64,7 +64,7 @@ class DHLPWC_Controller_Checkout
 
                 foreach($preset->options as $option) {
                     if ($option === DHLPWC_Model_Meta_Order_Option_Preference::OPTION_PS) {
-                        list($parcelshop_id, $country) = ($sync = WC()->session->get('dhlpwc_parcelshop_selection_sync')) ? $sync : array(null, null);
+                        list($parcelshop_id, $country, $search_value_memory) = ($sync = WC()->session->get('dhlpwc_parcelshop_selection_sync')) ? $sync : array(null, null, null);
                         $meta_service->save_option_preference($order_id, $option, $parcelshop_id);
                     } else {
                         $meta_service->save_option_preference($order_id, $option);

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/api/class-dhlpwc-model-api-connector.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/api/class-dhlpwc-model-api-connector.php
@@ -63,7 +63,7 @@ class DHLPWC_Model_API_Connector extends DHLPWC_Model_Core_Singleton_Abstract
     {
         if ($cache_time) {
             $cache_id = $endpoint.'_'.crc32(json_encode($params));
-            $cache = get_transient('dhlpwc_connector_cache_'.$cache_id);
+            $cache = get_transient('dhlpwc_connector_cache_' . $cache_id);
             if (!empty($cache)) {
                 return $cache;
             }
@@ -73,7 +73,7 @@ class DHLPWC_Model_API_Connector extends DHLPWC_Model_Core_Singleton_Abstract
         $parsed_response = $this->parse_response($response, $endpoint, $params);
         if ($parsed_response && $cache_time) {
             $cache_id = $endpoint . '_' . crc32(json_encode($params));
-            set_transient('dhlpwc_connector_cache_'.$cache_id, $parsed_response, $cache_time);
+            set_transient('dhlpwc_connector_cache_' . $cache_id, $parsed_response, $cache_time);
         }
         return $parsed_response;
     }
@@ -162,7 +162,7 @@ class DHLPWC_Model_API_Connector extends DHLPWC_Model_Core_Singleton_Abstract
         if ($add_bearer) {
             $request_params = array_merge_recursive($request_params, array(
                 'headers' => array(
-                    'Authorization' => 'Bearer '.$this->access_token,
+                    'Authorization' => 'Bearer ' . $this->access_token,
                 ),
             ));
         }

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/logic/class-dhlpwc-model-logic-access-control.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/logic/class-dhlpwc-model-logic-access-control.php
@@ -200,7 +200,7 @@ class DHLPWC_Model_Logic_Access_Control extends DHLPWC_Model_Core_Singleton_Abst
         $enabled = array();
 
         foreach($bulk_options as $bulk_option) {
-            if (isset($shipping_method['enable_bulk_option_'.$bulk_option]) && $shipping_method['enable_bulk_option_'.$bulk_option] == 'yes') {
+            if (isset($shipping_method['enable_bulk_option_' . $bulk_option]) && $shipping_method['enable_bulk_option_' . $bulk_option] == 'yes') {
                 $enabled[] = $bulk_option;
             }
         }
@@ -509,7 +509,7 @@ class DHLPWC_Model_Logic_Access_Control extends DHLPWC_Model_Core_Singleton_Abst
         }
 
         /** @var DHLPWC_Model_WooCommerce_Settings_Shipping_Method $shipping_method */
-        if ($shipping_method->get_option('enable_option_'.$option) !== 'yes') {
+        if ($shipping_method->get_option('enable_option_' . $option) !== 'yes') {
             return false;
         }
 
@@ -634,11 +634,11 @@ class DHLPWC_Model_Logic_Access_Control extends DHLPWC_Model_Core_Singleton_Abst
             return false;
         }
 
-        if (!isset($shipping_method['enable_shipping_day_'.$day])) {
+        if (!isset($shipping_method['enable_shipping_day_' . $day])) {
             return false;
         }
 
-        if ($shipping_method['enable_shipping_day_'.$day] != 'yes') {
+        if ($shipping_method['enable_shipping_day_' . $day] != 'yes') {
             return false;
         }
 

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-debug.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-debug.php
@@ -41,6 +41,16 @@ class DHLPWC_Model_Service_Debug extends DHLPWC_Model_Core_Singleton_Abstract
             return;
         }
 
+        $cache_time = 15 * MINUTE_IN_SECONDS;
+        $cache_id = $endpoint;
+        $cache = get_transient('dhlpwc_debug_mail_cache_' . $cache_id);
+        if (!empty($cache)) {
+            // Already mailed the error for this endpoint. Throttle amount of error mailing
+            return;
+        }
+
+        set_transient('dhlpwc_debug_mail_cache_' . $cache_id, true, $cache_time);
+
         $timestamp = current_time( 'timestamp', 1 );
         $title = 'ERROR: DHL for WooCommerce > ' . get_site_url() . ' > Endpoint:' . $endpoint . ' > (timestamp:' . $timestamp . ')';
 

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-delivery-times.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-delivery-times.php
@@ -30,7 +30,7 @@ class DHLPWC_Model_Service_Delivery_Times extends DHLPWC_Model_Core_Singleton_Ab
             'date'       => $date,
             'start_time' => $start_time,
             'end_time'   => $end_time,
-            'timestamp'  => strtotime($date.' '.$start_time),
+            'timestamp' => strtotime($date . ' ' . $start_time),
         ));
 
         return update_post_meta($order_id, self::ORDER_TIME_SELECTION, $meta_object->to_array());
@@ -100,6 +100,10 @@ class DHLPWC_Model_Service_Delivery_Times extends DHLPWC_Model_Core_Singleton_Ab
      */
     public function get_time_frames($postal_code, $country_code, $selected = null)
     {
+        if (!$postal_code || !$country_code) {
+            return array();
+        }
+
         $connector = DHLPWC_Model_API_Connector::instance();
         $time_windows = $connector->get('time-windows', array(
             'countryCode' => $country_code,
@@ -257,7 +261,7 @@ class DHLPWC_Model_Service_Delivery_Times extends DHLPWC_Model_Core_Singleton_Ab
         }
 
         // Add the additional days to the minimum timestamp
-        $minimum_timestamp = strtotime('+'.$additional_days.' days', $minimum_timestamp);
+        $minimum_timestamp = strtotime('+' . $additional_days . ' days', $minimum_timestamp);
 
         if ($minimum_timestamp > $timestamp) {
             return false;
@@ -285,19 +289,19 @@ class DHLPWC_Model_Service_Delivery_Times extends DHLPWC_Model_Core_Singleton_Ab
             return null;
         }
 
-        if (!isset($shipping_method['enable_delivery_time_'.$code])) {
+        if (!isset($shipping_method['enable_delivery_time_' . $code])) {
             return null;
         }
 
-        if ($shipping_method['enable_delivery_time_'.$code] != 'yes') {
+        if ($shipping_method['enable_delivery_time_' . $code] != 'yes') {
             return null;
         }
 
-        if (!isset($shipping_method['delivery_time_cut_off_'.$code])) {
+        if (!isset($shipping_method['delivery_time_cut_off_' . $code])) {
             return null;
         }
 
-        $cut_off_hour = (int) $shipping_method['delivery_time_cut_off_'.$code];
+        $cut_off_hour = (int) $shipping_method['delivery_time_cut_off_' . $code];
         $current_hour = (int) current_time('G');
 
 
@@ -312,15 +316,15 @@ class DHLPWC_Model_Service_Delivery_Times extends DHLPWC_Model_Core_Singleton_Ab
             }
         }
 
-        if (!isset($shipping_method['delivery_day_cut_off_'.$code])) {
+        if (!isset($shipping_method['delivery_day_cut_off_' . $code])) {
             return null;
         }
 
-        $days = (int) $shipping_method['delivery_day_cut_off_'.$code];
+        $days = (int) $shipping_method['delivery_day_cut_off_' . $code];
         $days += $cut_off ? 1 : 0;
 
         $current_timestamp = strtotime('yesterday 23:59:59');
-        $cut_off_timestamp = strtotime('+'.$days.' days', $current_timestamp);
+        $cut_off_timestamp = strtotime('+' . $days . ' days', $current_timestamp);
 
         return $cut_off_timestamp;
     }
@@ -445,7 +449,7 @@ class DHLPWC_Model_Service_Delivery_Times extends DHLPWC_Model_Core_Singleton_Ab
 
     public function get_identifier($date, $start_time, $end_time)
     {
-        return $date.'___'.$start_time.'___'.$end_time;
+        return $date . '___' . $start_time . '___' . $end_time;
     }
 
 }

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-label-metabox.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-label-metabox.php
@@ -200,7 +200,7 @@ class DHLPWC_Model_Service_Label_Metabox extends DHLPWC_Model_Core_Singleton_Abs
                 }
 
                 if (!empty($option->input_template)) {
-                    $view = new DHLPWC_Template('order.meta.form.input.'.$option->input_template);
+                    $view = new DHLPWC_Template('order.meta.form.input.' . $option->input_template);
                     $option->input_template = $view->render($option->input_template_data, false);
                 }
 

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-parcelshop.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-parcelshop.php
@@ -25,7 +25,7 @@ class DHLPWC_Model_Service_Parcelshop extends DHLPWC_Model_Core_Singleton_Abstra
             return array();
         }
 
-        $parcelshops_data = $connector->get('parcel-shop-locations/'.$country, array(
+        $parcelshops_data = $connector->get('parcel-shop-locations/' . $country, array(
             'limit' => $limit,
             'fuzzy' => $search,
         ), 10 * MINUTE_IN_SECONDS);
@@ -53,10 +53,41 @@ class DHLPWC_Model_Service_Parcelshop extends DHLPWC_Model_Core_Singleton_Abstra
         }
 
         $connector = DHLPWC_Model_API_Connector::instance();
-        $parcelshop_data = $connector->get(sprintf('parcel-shop-locations/'.$country.'/%s', $parcelshop_id), null, 1 * HOUR_IN_SECONDS);
+        $parcelshop_data = $connector->get(sprintf('parcel-shop-locations/' . $country . '/%s', $parcelshop_id), null, 1 * HOUR_IN_SECONDS);
         if (!$parcelshop_data) {
             return null;
         }
+        $parcelshop = new DHLPWC_Model_API_Data_Parcelshop($parcelshop_data);
+        $parcelshop->country = $country;
+
+        return $parcelshop;
+    }
+
+    public function search_parcelshop($postal_search, $country)
+    {
+        if (!$postal_search) {
+            return null;
+        }
+
+        if (!$this->validate_country($country)) {
+            return null;
+        }
+
+        $connector = DHLPWC_Model_API_Connector::instance();
+        $parcelshops_data = $connector->get('parcel-shop-locations/' . $country, array(
+            'limit'   => 1,
+            'zipCode' => trim($postal_search),
+        ), 1 * HOUR_IN_SECONDS);
+
+        if (empty($parcelshops_data) || !is_array($parcelshops_data)) {
+            return null;
+        }
+
+        $parcelshop_data = reset($parcelshops_data);
+        if (!$parcelshop_data) {
+            return null;
+        }
+
         $parcelshop = new DHLPWC_Model_API_Data_Parcelshop($parcelshop_data);
         $parcelshop->country = $country;
 

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-postcode.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-postcode.php
@@ -20,7 +20,7 @@ class DHLPWC_Model_Service_Postcode extends DHLPWC_Model_Core_Singleton_Abstract
             return true;
         }
 
-        $valid = (bool) preg_match( '/^'.$expression.'$/', $postcode );
+        $valid = (bool)preg_match('/^' . $expression . '$/', $postcode);
         return $valid;
     }
 
@@ -69,7 +69,7 @@ class DHLPWC_Model_Service_Postcode extends DHLPWC_Model_Core_Singleton_Abstract
         if (!isset($this->cached_countries) || !is_array($this->cached_countries)) {
             $this->cached_countries = array();
         }
-        set_site_transient('dhlpwc_postcode_validation_'.$country_code, $expression, 7 * DAY_IN_SECONDS);
+        set_site_transient('dhlpwc_postcode_validation_' . $country_code, $expression, 7 * DAY_IN_SECONDS);
         $this->cached_countries[$country_code] = $expression;
     }
 
@@ -80,7 +80,7 @@ class DHLPWC_Model_Service_Postcode extends DHLPWC_Model_Core_Singleton_Abstract
         }
 
         if (!array_key_exists($country_code, $this->cached_countries)) {
-            if ($expression = get_site_transient('dhlpwc_postcode_validation'.$country_code)) {
+            if ($expression = get_site_transient('dhlpwc_postcode_validation' . $country_code)) {
                 $this->cached_countries[$country_code] = $expression;
             } else {
                 return false;

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-shipping-preset.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-shipping-preset.php
@@ -185,11 +185,11 @@ class DHLPWC_Model_Service_Shipping_Preset extends DHLPWC_Model_Core_Singleton_A
             return 0;
         }
 
-        if (empty($shipping_method['sort_position_'.$setting_id])) {
+        if (empty($shipping_method['sort_position_' . $setting_id])) {
             return 0;
         }
 
-        return intval($shipping_method['sort_position_'.$setting_id]);
+        return intval($shipping_method['sort_position_' . $setting_id]);
     }
 
     /**
@@ -202,7 +202,7 @@ class DHLPWC_Model_Service_Shipping_Preset extends DHLPWC_Model_Core_Singleton_A
         foreach($presets as $preset_data)
         {
             $preset = new DHLPWC_Model_Meta_Shipping_Preset($preset_data);
-            if ('dhlpwc-'.$preset->frontend_id === $frontend_id) {
+            if ('dhlpwc-' . $preset->frontend_id === $frontend_id) {
                 return $preset;
             }
         }

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/delivery-times-option.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/delivery-times-option.php
@@ -1,7 +1,7 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <div class="dhlpwc-shipping-method-delivery-times-option"
-    <?php echo !empty($postal_code) ? 'data-postal-code-value="'.$postal_code.'"' : '' ?>
-    <?php echo !empty($country_code) ? 'data-country-code="'.$country_code.'"' : '' ?>
+    <?php echo !empty($postal_code) ? 'data-postal-code-value="' . $postal_code . '"' : '' ?>
+    <?php echo !empty($country_code) ? 'data-country-code="' . $country_code . '"' : '' ?>
 >
 
     <?php if (!empty($delivery_times)) : ?>

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/parcelshop-locator.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/parcelshop-locator.php
@@ -1,3 +1,9 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
-<div id="dhlpwc-parcelshop-locator-wrapper">
-</div>
+<div id="dhl-servicepoint-locator-component"
+     data-query=""
+     data-limit="7"
+     data-disable-refresh="true"
+     data-disable-url-sync="true"
+     data-onchange="dhlpwc_select_servicepoint"
+     data-setup="dhlpwc_reset_servicepoint"
+></div>

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/parcelshop-option.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/parcelshop-option.php
@@ -1,7 +1,7 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <div class="dhlpwc-shipping-method-parcelshop-option"
-    <?php echo !empty($search_value) ? 'data-search-value="'.$search_value.'"' : '' ?>
-    <?php echo !empty($country_code) ? 'data-country-code="'.$country_code.'"' : '' ?>
+    <?php echo !empty($search_value) ? 'data-search-value="' . $search_value . '"' : '' ?>
+    <?php echo !empty($country_code) ? 'data-country-code="' . $country_code . '"' : '' ?>
 >
     <?php if (!empty($parcelshop)) : ?>
         <span class="dhlpwc-parcelshop-option-message dhlpwc_notice"><?php echo $parcelshop->name ?></span><br/>


### PR DESCRIPTION
- Updated the ServicePoint locator to load from DHL's own servers instead of third party
- Updated the ServicePoint locator to select the closest ServicePoint automatically
- Added developer filters for price manipulation
- Fixed delivery times API call to not send data when no postal code is set
- Fixed tax adjustment calculation