### PR TITLE
1.5.7 DHL Parcel update:

### DIFF
--- a/pr-dhl-woocommerce/dhlpwoocommerce/README.md
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/README.md
@@ -1,5 +1,13 @@
 # DHL Parcel plugin for WooCommerce
 
+v1.2.15
+
+## Changes
+- Added a setting to change order status after label creation
+- Fixed an issue with the settings menu jumping on certain browsers
+- Fixed an issue with unavailable service combinations on bulk creation
+- Removed number validation on addresses due to some addresses not requiring it
+
 v1.2.14
 
 ## Changes

--- a/pr-dhl-woocommerce/dhlpwoocommerce/assets/css/dhlpwc.admin.css
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/assets/css/dhlpwc.admin.css
@@ -247,8 +247,7 @@ input#woocommerce_dhlpwc_search_printers.dhlpwc_button_fail {
     display: none;
     margin-right: -240px;
     padding: 0 20px;
-    border-top: solid 5px #ffffff;
-    border-bottom: solid 5px #ffffff;
+    height: 0;
 }
 
 #mainform > #dhlpwc_shipping_method_settings > h3,

--- a/pr-dhl-woocommerce/dhlpwoocommerce/assets/css/dhlpwc.admin_settings_only.css
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/assets/css/dhlpwc.admin_settings_only.css
@@ -1,0 +1,4 @@
+#footer-left,
+#footer-upgrade{
+    display: none;
+}

--- a/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
@@ -4,7 +4,7 @@ Plugin Name: DHL Parcel for WooCommmerce
 Plugin URI: https://www.dhlparcel.nl
 Description: This is the official DHL Parcel for WooCommerce plugin.
 Author: DHL Parcel
-Version: 1.2.14
+Version: 1.2.15
 WC requires at least: 3.0.0
 WC tested up to: 3.5.3
 */

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/admin/class-dhlpwc-controller-admin-settings.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/admin/class-dhlpwc-controller-admin-settings.php
@@ -133,6 +133,10 @@ class DHLPWC_Controller_Admin_Settings
         if ($this->is_plugin_screen() || $this->is_shipping_zone_screen()) {
             wp_enqueue_style('dhlpwc-admin-style', DHLPWC_PLUGIN_URL . 'assets/css/dhlpwc.admin.css');
         }
+
+        if ($this->is_plugin_screen()) {
+            wp_enqueue_style('dhlpwc-admin_settings_only-style', DHLPWC_PLUGIN_URL . 'assets/css/dhlpwc.admin_settings_only.css');
+        }
     }
 
     public function load_scripts()

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-order-meta-option.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-order-meta-option.php
@@ -61,13 +61,16 @@ class DHLPWC_Model_Service_Order_Meta_Option extends DHLPWC_Model_Core_Singleton
         }
 
         $allowed_shipping_options = $service->check(DHLPWC_Model_Service_Access_Control::ACCESS_CAPABILITY_ORDER_OPTIONS, array(
-            'order_id' => $order_id,
-            'options' => $options,
+            'order_id'    => $order_id,
+            'options'     => $options,
             'to_business' => $to_business,
         ));
 
+        $exclusions = $this->get_exclusions($allowed_shipping_options, $options);
+
         // Disable automatic checking of send signature if there are no parceltypes for it
-        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_HANDT, $allowed_shipping_options)) {
+        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_HANDT, $allowed_shipping_options)
+            || in_array(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_HANDT, $exclusions)) {
             return false;
         }
 
@@ -83,13 +86,16 @@ class DHLPWC_Model_Service_Order_Meta_Option extends DHLPWC_Model_Core_Singleton
         }
 
         $allowed_shipping_options = $service->check(DHLPWC_Model_Service_Access_Control::ACCESS_CAPABILITY_ORDER_OPTIONS, array(
-            'order_id' => $order_id,
-            'options' => $options,
+            'order_id'    => $order_id,
+            'options'     => $options,
             'to_business' => $to_business,
         ));
 
+        $exclusions = $this->get_exclusions($allowed_shipping_options, $options);
+
         // Disable automatic checking of age check if there are no parceltypes for it
-        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_AGE_CHECK, $allowed_shipping_options)) {
+        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_AGE_CHECK, $allowed_shipping_options)
+            || in_array(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_AGE_CHECK, $exclusions)) {
             return false;
         }
 
@@ -105,13 +111,16 @@ class DHLPWC_Model_Service_Order_Meta_Option extends DHLPWC_Model_Core_Singleton
         }
 
         $allowed_shipping_options = $service->check(DHLPWC_Model_Service_Access_Control::ACCESS_CAPABILITY_ORDER_OPTIONS, array(
-            'order_id' => $order_id,
-            'options' => $options,
+            'order_id'    => $order_id,
+            'options'     => $options,
             'to_business' => $to_business,
         ));
 
+        $exclusions = $this->get_exclusions($allowed_shipping_options, $options);
+
         // Disable automatic checking of order id reference if there are no parceltypes for it
-        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_REFERENCE, $allowed_shipping_options)) {
+        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_REFERENCE, $allowed_shipping_options)
+            || in_array(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_REFERENCE, $exclusions)) {
             return false;
         }
 
@@ -127,13 +136,16 @@ class DHLPWC_Model_Service_Order_Meta_Option extends DHLPWC_Model_Core_Singleton
         }
 
         $allowed_shipping_options = $service->check(DHLPWC_Model_Service_Access_Control::ACCESS_CAPABILITY_ORDER_OPTIONS, array(
-            'order_id' => $order_id,
-            'options' => $options,
+            'order_id'    => $order_id,
+            'options'     => $options,
             'to_business' => $to_business,
         ));
 
+        $exclusions = $this->get_exclusions($allowed_shipping_options, $options);
+
         // Disable automatic checking of add return label if there are no parceltypes for it
-        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_ADD_RETURN_LABEL, $allowed_shipping_options)) {
+        if (!array_key_exists(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_ADD_RETURN_LABEL, $allowed_shipping_options)
+            || in_array(DHLPWC_Model_Meta_Order_Option_Preference::OPTION_ADD_RETURN_LABEL, $exclusions)) {
             return false;
         }
 
@@ -197,6 +209,20 @@ class DHLPWC_Model_Service_Order_Meta_Option extends DHLPWC_Model_Core_Singleton
             $array[] = $key;
         }
         return $array;
+    }
+
+    protected function get_exclusions($allowed_shipping_options, $options)
+    {
+        $exclusions = [];
+        foreach ($options as $option){
+            foreach ($allowed_shipping_options[$option]->exclusions as $exclusion)
+            {
+                if(!in_array($exclusion,$exclusions)){
+                    $exclusions[]=$exclusion->key;
+                }
+            }
+        }
+        return $exclusions;
     }
 
 }

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/woocommerce/settings/class-dhlpwc-model-woocommerce-settings-shipping-method.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/woocommerce/settings/class-dhlpwc-model-woocommerce-settings-shipping-method.php
@@ -163,6 +163,31 @@ class DHLPWC_Model_WooCommerce_Settings_Shipping_Method extends WC_Shipping_Meth
                         '</a>'
                     ),
                 ),
+                'change_order_status_from_wc-pending' => array(
+                    'title'       => __('Apply status change when creating a label', 'dhlpwc'),
+                    'type'        => 'checkbox',
+                    'label'       => __('Change status if order is: Pending payment', 'dhlpwc'),
+                    'default'     => 'no',
+                    'class'       => 'change_order_status_from'
+                ),
+                'change_order_status_from_wc-processing' => array(
+                    'type'        => 'checkbox',
+                    'label'       => __('Change status if order is: Processing', 'dhlpwc'),
+                    'default'     => 'no',
+                ),
+                'change_order_status_from_wc-on-hold' => array(
+                    'type'        => 'checkbox',
+                    'label'       => __('Change status if order is: On hold', 'dhlpwc'),
+                    'default'     => 'no',
+                ),
+                'change_order_status_to' => array(
+                    'type'    => 'select',
+                    'options' => array_merge(
+                        array('null' => __('Do not change order status')),
+                        array_map(array($this, 'change_order_status_to_option_update'), wc_get_order_statuses())
+                    ),
+                    'default' => 'null',
+                ),
 
                 // API settings
                 'api_settings'                      => array(
@@ -999,6 +1024,10 @@ class DHLPWC_Model_WooCommerce_Settings_Shipping_Method extends WC_Shipping_Meth
         return $package['cart_subtotal'];
     }
 
+    protected function change_order_status_to_option_update($option)
+    {
+        return __('Change status to: ') . $option;
+    }
 }
 
 endif;

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/order/meta/form/input/address.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/order/meta/form/input/address.php
@@ -42,7 +42,7 @@
     <?php endif ?>
 />
 
-<label class="dhlpwc-metabox-adress-label"><?php _e('Number', 'dhlpwc') ?></label> <div class="dhlpwc-required-field-star">*</div>
+<label class="dhlpwc-metabox-adress-label"><?php _e('Number', 'dhlpwc') ?></label>
 <input type="text" class="dhlpwc-metabox-address-input" id="dhlpwc-metabox-address-number"
     <?php if (!empty($address) && !empty($address->number)) : ?>
         value="<?php echo esc_attr($address->number) ?>"

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: WooCommerce integration for DHL eCommerce, DHL Paket, DHL Parcel Europe (Benelux and Iberia) and Deutsche Post International
  * Author: DHL
  * Author URI: http://dhl.com/woocommerce
- * Version: 1.5.6
+ * Version: 1.5.7
  * WC requires at least: 2.6.14
  * WC tested up to: 3.7
  *
@@ -32,7 +32,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 class PR_DHL_WC {
 
-	private $version = "1.5.6";
+	private $version = "1.5.7";
 
 	/**
 	 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -5,7 +5,7 @@ Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL express, DHL Parcel NL, DHL P
 Requires at least: 4.1
 Requires PHP: 5.6
 Tested up to: 5.2
-Stable tag: 1.5.6
+Stable tag: 1.5.7
 WC requires at least: 2.6.14
 WC tested up to: 3.7
 License: GPLv2 or later
@@ -80,6 +80,12 @@ Click [here](www.dhl.com/faqs) for our FAQs or check out our [integration page](
 
 
 == Changelog ==
+
+= 1.5.7 =
+- Added a setting to change order status after label creation
+- Fixed an issue with the settings menu jumping on certain browsers
+- Fixed an issue with unavailable service combinations on bulk creation
+- Removed number validation on addresses due to some addresses not requiring it
 
 = 1.5.6 =
 * DHL Parcel: Fixed issue with package rate not being properly calculated based on logged in users

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -82,10 +82,10 @@ Click [here](www.dhl.com/faqs) for our FAQs or check out our [integration page](
 == Changelog ==
 
 = 1.5.7 =
-- Added a setting to change order status after label creation
-- Fixed an issue with the settings menu jumping on certain browsers
-- Fixed an issue with unavailable service combinations on bulk creation
-- Removed number validation on addresses due to some addresses not requiring it
+- DHL Parcel: Added a setting to change order status after label creation
+- DHL Parcel: Fixed an issue with the settings menu jumping on certain browsers
+- DHL Parcel: Fixed an issue with unavailable service combinations on bulk creation
+- DHL Parcel: Removed number validation on addresses due to some addresses not requiring it
 
 = 1.5.6 =
 * DHL Parcel: Fixed issue with package rate not being properly calculated based on logged in users


### PR DESCRIPTION
- Added a setting to change order status after label creation
- Fixed an issue with the settings menu jumping on certain browsers
- Fixed an issue with unavailable service combinations on bulk creation
- Removed number validation on addresses due to some addresses not requiring it