### PR TITLE
Release 1.6.7

### DIFF
--- a/pr-dhl-woocommerce/dhlpwoocommerce/README.md
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/README.md
@@ -1,5 +1,11 @@
 # DHL Parcel plugin for WooCommerce
 
+v1.2.18
+
+## Changes
+- Added a postnumber input pop-up for Packstations that require it with the mapless locator 
+- Fixed an issue with logged in users not seeing shipping methods in the checkout
+
 v1.2.17
 
 ## Changes

--- a/pr-dhl-woocommerce/dhlpwoocommerce/assets/js/dhlpwc.parcelshop.select.js
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/assets/js/dhlpwc.parcelshop.select.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function ($) {
-    let dhlpwc_parcelshop_selector_timeout = null;
+    var dhlpwc_parcelshop_selector_timeout = null;
 
-    let dhlpwc_shipping_input_name = '_unavailable_option_';
+    var dhlpwc_shipping_input_name = '_unavailable_option_';
     if ($('[id^=shipping_method_][id$=_dhlpwc-parcelshop]').length > 0) {
         dhlpwc_shipping_input_name = $('[id^=shipping_method_][id$=_dhlpwc-parcelshop]').attr('name')
                                                                                         .replace(/(:|\.|\[|\])/g, '\\$1');
@@ -10,17 +10,36 @@ jQuery(document).ready(function ($) {
     $(document.body).on('click', '.dhlpwc-parcelshop-option-change', function (e) {
         e.preventDefault();
         if ($('[id^=shipping_method_][id$=_dhlpwc-parcelshop]').is(':checked')) {
-            $('.dhlpwc-parcelshop-option-list').toggle();
+            var container = $('.dhlpwc-parcelshop-option-list');
+            $(document).mouseup(function (e) {
+                if (!container.is(e.target) && container.has(e.target).length === 0) {
+                    container.hide();
+                }
+            });
+            container.toggle();
             $(document.body).trigger('dhlpwc:show_parcelshop_selector_refresh');
         }
 
     }).on('click', '.dhlpwc-parcelshop-option-list-item', function (e) {
         e.preventDefault();
         if ($('[id^=shipping_method_][id$=_dhlpwc-parcelshop]').is(':checked')) {
-            const parcelshop_id = $(this).attr('data-parcelshop-id');
-            const country_code = $('.dhlpwc-shipping-method-parcelshop-option').data('country-code');
-            $(document.body).trigger('dhlpwc:parcelshop_selection_sync', [parcelshop_id, country_code]);
-            $('.dhlpwc-parcelshop-option-list').hide();
+            var dhlpwc_selected_parcelshop_id = $(this).attr('data-parcelshop-id');
+            var parcelshop_type = $(this).attr('data-parcelshop-type');
+            var country_code = $('.dhlpwc-shipping-method-parcelshop-option').data('country-code');
+
+            if (typeof parcelshop_type !== 'undefined' && parcelshop_type === 'packStation' && country_code === 'DE') {
+                var dhlpwc_additional_parcelshop_id = prompt("Add your 'postnumber' for delivery at a DHL Packstation:");
+                if (dhlpwc_additional_parcelshop_id != null && dhlpwc_additional_parcelshop_id != '') {
+                    dhlpwc_selected_parcelshop_id += '|' + dhlpwc_additional_parcelshop_id;
+                    $(document.body).trigger("dhlpwc:parcelshop_selection_sync", [dhlpwc_selected_parcelshop_id, country_code]);
+                    $('.dhlpwc-parcelshop-option-list').hide();
+                }else{
+                    alert("'postnumber' is required");
+                }
+            } else {
+                $(document.body).trigger('dhlpwc:parcelshop_selection_sync', [dhlpwc_selected_parcelshop_id, country_code]);
+                $('.dhlpwc-parcelshop-option-list').hide();
+            }
         }
     }).on('keyup', '.dhlpwc-parcelshop-option-list-search input', function (e) {
         if ($('[id^=shipping_method_][id$=_dhlpwc-parcelshop]').is(':checked')) {
@@ -31,7 +50,7 @@ jQuery(document).ready(function ($) {
         }
 
     }).on('dhlpwc:show_parcelshop_selector_refresh', function () {
-        const url = dhlpwc_parcelshop_selector.servicepoint_url + $('.dhlpwc-shipping-method-parcelshop-option')
+        var url = dhlpwc_parcelshop_selector.servicepoint_url + $('.dhlpwc-shipping-method-parcelshop-option')
                 .data('country-code') +
             '?limit=' + dhlpwc_parcelshop_selector.limit + '&fuzzy=' + encodeURI($('.dhlpwc-parcelshop-option-list-search input')
                 .val())
@@ -40,10 +59,10 @@ jQuery(document).ready(function ($) {
             // Remove existing elements from list before appending
             $('.dhlpwc-parcelshop-option-list-item.parcelshop-option').remove();
             data.forEach(function (parcelShop) {
-                const parcelShopLocation = (parcelShop.address.countryCode === 'FR' ? parcelShop.address.number + ' ' + parcelShop.address.street : parcelShop.address.street + ' ' + parcelShop.address.number) +
+                var parcelShopLocation = (parcelShop.address.countryCode === 'FR' ? parcelShop.address.number + ' ' + parcelShop.address.street : parcelShop.address.street + ' ' + parcelShop.address.number) +
                     ', ' + parcelShop.address.zipCode + ', ' + parcelShop.address.city;
                 $('.dhlpwc-parcelshop-option-list')
-                    .append('<div class="dhlpwc-parcelshop-option-list-item parcelshop-option" data-parcelshop-id="' + parcelShop.id + '">' +
+                    .append('<div class="dhlpwc-parcelshop-option-list-item parcelshop-option" data-parcelshop-type="' + parcelShop.shopType + '" data-parcelshop-id="' + parcelShop.id + '">' +
                         '<strong>' + parcelShop.name + '</strong><br>' +
                         '<span>' + parcelShopLocation + '</span></div>')
             });

--- a/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
@@ -4,7 +4,7 @@ Plugin Name: DHL Parcel for WooCommmerce
 Plugin URI: https://www.dhlparcel.nl
 Description: This is the official DHL Parcel for WooCommerce plugin.
 Author: DHL Parcel
-Version: 1.2.17
+Version: 1.2.18
 WC requires at least: 3.0.0
 WC tested up to: 3.5.3
 */

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/class-dhlpwc-controller-checkout.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/controller/class-dhlpwc-controller-checkout.php
@@ -66,11 +66,11 @@ class DHLPWC_Controller_Checkout
                     if ($option === DHLPWC_Model_Meta_Order_Option_Preference::OPTION_PS) {
                         $sync = WC()->session->get('dhlpwc_parcelshop_selection_sync');
                         if ($sync) {
-                            list($parcelshop_id, $country_code, $search_value_memory) = $sync;
+                            list($parcelshop_id, $country_code, $postal_code_memory) = $sync;
                         } else {
-                            list($parcelshop_id, $country_code, $search_value_memory) = array(null, null, null);
+                            list($parcelshop_id, $country_code, $postal_code_memory) = array(null, null, null);
                         }
-                        unset($country_code, $search_value_memory);
+                        unset($country_code, $postal_code_memory);
 
                         $meta_service->save_option_preference($order_id, $option, $parcelshop_id);
                     } else {
@@ -86,11 +86,11 @@ class DHLPWC_Controller_Checkout
         if (isset($data['shipping_method']) && is_array($data['shipping_method']) && in_array('dhlpwc-parcelshop', $data['shipping_method'])) {
             $sync = WC()->session->get('dhlpwc_parcelshop_selection_sync');
             if ($sync) {
-                list($parcelshop_id, $country_code, $search_value_memory) = $sync;
+                list($parcelshop_id, $country_code, $postal_code_memory) = $sync;
             } else {
-                list($parcelshop_id, $country_code, $search_value_memory) = array(null, null, null);
+                list($parcelshop_id, $country_code, $postal_code_memory) = array(null, null, null);
             }
-            unset($search_value_memory);
+            unset($postal_code_memory);
 
             if (empty($parcelshop_id) || empty($country_code)) {
                 $errors->add('dhlpwc_parcelshop_selection_sync', __('Choose a DHL ServicePoint', 'dhlpwc'));

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/logic/class-dhlpwc-model-logic-access-control-capabilities.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/logic/class-dhlpwc-model-logic-access-control-capabilities.php
@@ -155,23 +155,17 @@ class DHLPWC_Model_Logic_Access_Control_Capabilities extends DHLPWC_Model_Core_S
     {
         $customer = WC()->customer;
         if ($customer) {
-            if (is_callable(array($customer, 'get_shipping'))) {
-                // WooCommerce 3.2.0+
-                return new DHLPWC_Model_Meta_Address($customer->get_shipping());
-            } else {
-                // WooCommerce < 3.2.0
-                return new DHLPWC_Model_Meta_Address(array(
-                    'first_name' => $customer->shipping_first_name,
-                    'last_name'  => $customer->shipping_last_name,
-                    'company'    => $customer->shipping_company,
-                    'address_1'  => $customer->get_shipping_address(),
-                    'address_2'  => $customer->get_shipping_address_2(),
-                    'city'       => $customer->get_shipping_city(),
-                    'state'      => $customer->get_shipping_state(),
-                    'postcode'   => $customer->get_shipping_postcode(),
-                    'country'    => $customer->get_shipping_country(),
-                ));
-            }
+            return new DHLPWC_Model_Meta_Address(array(
+                'first_name' => $customer->shipping_first_name,
+                'last_name'  => $customer->shipping_last_name,
+                'company'    => $customer->shipping_company,
+                'address_1'  => $customer->get_shipping_address(),
+                'address_2'  => $customer->get_shipping_address_2(),
+                'city'       => $customer->get_shipping_city(),
+                'state'      => $customer->get_shipping_state(),
+                'postcode'   => $customer->get_shipping_postcode(),
+                'country'    => $customer->get_shipping_country(),
+            ));
         }
 
         return new DHLPWC_Model_Meta_Address();

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/parcelshop-option.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/view/cart/parcelshop-option.php
@@ -2,7 +2,7 @@
     exit;
 } ?>
 <div class="dhlpwc-shipping-method-parcelshop-option"
-    <?php echo !empty($search_value) ? 'data-search-value="' . $search_value . '"' : '' ?>
+    <?php echo !empty($postal_code) ? 'data-search-value="' . $postal_code . '"' : '' ?>
     <?php echo !empty($country_code) ? 'data-country-code="' . $country_code . '"' : '' ?>
 >
     <?php if (!empty($parcelshop)) : ?>
@@ -17,7 +17,7 @@
             <div class="dhlpwc-parcelshop-option-list-search">
                 <input type="text"
                        placeholder="<?php _e('Search by postcode, city or name', 'dhlpwc') ?>"
-                       value="<?php echo $search_value ?>"></div>
+                       value="<?php echo $postal_code ?>"></div>
         </div>
     </div>
 </div>

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: WooCommerce integration for DHL eCommerce, DHL Paket, DHL Parcel Europe (Benelux and Iberia) and Deutsche Post International
  * Author: DHL
  * Author URI: http://dhl.com/woocommerce
- * Version: 1.6.6
+ * Version: 1.6.7
  * WC requires at least: 2.6.14
  * WC tested up to: 4.0
  *
@@ -32,7 +32,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 class PR_DHL_WC {
 
-	private $version = "1.6.6";
+	private $version = "1.6.7";
 
 	/**
 	 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -5,7 +5,7 @@ Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL express, DHL Parcel NL, DHL P
 Requires at least: 4.1
 Requires PHP: 5.6
 Tested up to: 5.2
-Stable tag: 1.6.6
+Stable tag: 1.6.7
 WC requires at least: 2.6.14
 WC tested up to: 4.0
 License: GPLv2 or later
@@ -76,6 +76,10 @@ Click [here](www.dhl.com/faqs) for our FAQs or check out our [integration page](
 
 
 == Changelog ==
+
+= 1.6.7 =
+* DHL Parcel: Added a postnumber input pop-up for Packstations that require it with the mapless locator
+* DHL Parcel: Fixed an issue with logged in users not seeing shipping methods in the checkout
 
 = 1.6.6 =
 * Deutsche Post: Fix item level value formatting


### PR DESCRIPTION
* DHL Parcel: Added a postnumber input pop-up for Packstations that require it with the mapless locator
* DHL Parcel: Fixed an issue with logged in users not seeing shipping methods in the checkout