### PR TITLE
Release 2.8.3 (DHL Parcel)

### DIFF
--- a/pr-dhl-woocommerce/dhlpwoocommerce/README.md
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/README.md
@@ -1,5 +1,9 @@
 # DHL Parcel plugin for WooCommerce
  
+v1.3.18
+## Changes
+- Added a new available action hook for label creation
+ 
 v1.3.17
 ## Changes
 - Small fix for ServicePoint locator in checkout

--- a/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/dhlpwoocommerce.php
@@ -4,7 +4,7 @@ Plugin Name: DHL Parcel for WooCommmerce
 Plugin URI: https://www.dhlparcel.nl
 Description: This is the official DHL Parcel for WooCommerce plugin.
 Author: DHL Parcel
-Version: 1.3.18
+Version: 1.3.19
 WC requires at least: 3.0.0
 WC tested up to: 4.3.3
 */

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/logic/class-dhlpwc-model-logic-access-control-capabilities.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/logic/class-dhlpwc-model-logic-access-control-capabilities.php
@@ -32,10 +32,14 @@ class DHLPWC_Model_Logic_Access_Control_Capabilities extends DHLPWC_Model_Core_S
     {
         if ($one->max_weight_kg === $two->max_weight_kg) {
             // Weight is the same, sort by dimensions
-            return $one->dimensions->max_length_cm * $one->dimensions->max_height_cm * $one->dimensions->max_width_cm >
-                $two->dimensions->max_length_cm * $two->dimensions->max_height_cm * $two->dimensions->max_width_cm;
+            $dimension_one = $one->dimensions->max_length_cm * $one->dimensions->max_height_cm * $one->dimensions->max_width_cm;
+            $dimension_two = $two->dimensions->max_length_cm * $two->dimensions->max_height_cm * $two->dimensions->max_width_cm;
+            if ($dimension_one === $dimension_two) {
+                return 0;
+            }
+            return $dimension_one > $dimension_two ? 1 : -1;
         }
-        return $one->max_weight_kg > $two->max_weight_kg;
+        return $one->max_weight_kg > $two->max_weight_kg ? 1 : -1;
     }
 
     public function filter_unique_options($capabilities)

--- a/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-label-metabox.php
+++ b/pr-dhl-woocommerce/dhlpwoocommerce/includes/model/service/class-dhlpwc-model-service-label-metabox.php
@@ -251,9 +251,12 @@ class DHLPWC_Model_Service_Label_Metabox extends DHLPWC_Model_Core_Singleton_Abs
     {
         $view = new DHLPWC_Template('order.meta.form.sizes-headline');
         $option_texts = $selected_options;
-        array_walk($option_texts, function(&$value, &$key) {
-            $value = DHLPWC_Model_Service_Translation::instance()->option($value);
-        });
+        $option_texts = array_map(
+            function ($value) {
+                return DHLPWC_Model_Service_Translation::instance()->option($value);
+            },
+            $option_texts
+        );
 
         $size_view = $view->render(array(
             'message' => implode(' + ', $option_texts),

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -7,7 +7,7 @@
  * Author URI: http://dhl.com/
  * Text Domain: dhl-for-woocommerce
  * Domain Path: /lang
- * Version: 2.8.2
+ * Version: 2.8.3
  * WC requires at least: 3.0
  * WC tested up to: 5.6
  * Requires at least: 4.6
@@ -35,7 +35,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 class PR_DHL_WC {
 
-	private $version = "2.8.2";
+	private $version = "2.8.3";
 
 	/**
 	 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -5,7 +5,7 @@ Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL express, DHL Parcel NL, DHL P
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 5.9
-Stable tag: 2.8.2
+Stable tag: 2.8.3
 WC requires at least: 3.0
 WC tested up to: 6.1
 License: GPLv2 or later
@@ -74,6 +74,10 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+ 
+= 2.8.3 =
+* DHL Parcel: Fixed a deprecation warning on sorted package sized in the label creation screen for PHP 8 compatibility
+* DHL Parcel: Fixed a reference warning in the label creation screen for PHP 8 compatibility
  
 = 2.8.2 =
 * DHL Paket: Fix drop-off points. Switched to Unified REST API for drop-off points.


### PR DESCRIPTION
* DHL Parcel: Fixed a deprecation warning on sorted package sized in the label creation screen for PHP 8 compatibility
* DHL Parcel: Fixed a reference warning in the label creation screen for PHP 8 compatibility