### PR TITLE
Allow Address 2 to be empty

### DIFF
--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
@@ -451,8 +451,8 @@ class PR_DHL_API_SOAP_Label extends PR_DHL_API_SOAP implements PR_DHL_API_Label 
 			throw new Exception( __('Post Number is missing, it is mandatory for "Packstation" delivery.', 'dhl-for-woocommerce') );
 		}
 
-		// Check address 2 if no parcel shop is being selected
-		if ( ! $this->pos_ps && ! $this->pos_rs && ! $this->pos_po ) {
+		// Check address 2 if inside Germany and no parcel shop is being selected
+		if ( 'DE' === $args['shipping_address']['country'] && ! $this->pos_ps && ! $this->pos_rs && ! $this->pos_po ) {
 			// If address 2 missing, set last piece of an address to be address 2
 			if ( empty( $args['shipping_address']['address_2'] )) {
 			    $set_key = false;

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
@@ -451,8 +451,8 @@ class PR_DHL_API_SOAP_Label extends PR_DHL_API_SOAP implements PR_DHL_API_Label 
 			throw new Exception( __('Post Number is missing, it is mandatory for "Packstation" delivery.', 'dhl-for-woocommerce') );
 		}
 
-		// Check address 2 if inside Germany and no parcel shop is being selected
-		if ( 'DE' === $args['shipping_address']['country'] && ! $this->pos_ps && ! $this->pos_rs && ! $this->pos_po ) {
+		// Check address 2 if no parcel shop is being selected
+		if ( ! $this->pos_ps && ! $this->pos_rs && ! $this->pos_po ) {
 			// If address 2 missing, set last piece of an address to be address 2
 			if ( empty( $args['shipping_address']['address_2'] )) {
 			    $set_key = false;

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
@@ -469,32 +469,34 @@ class PR_DHL_API_SOAP_Label extends PR_DHL_API_SOAP implements PR_DHL_API_Label 
                     }
                 }
 
-				// Loop through address and set number value only...
-				// ...last found number will be 'address_2'
-				foreach ($address_exploded as $address_key => $address_value) {
-					if (is_numeric($address_value)) {
-						// Set last index as street number
+				if( count($address_exploded) > 1 ) {
+					// Loop through address and set number value only...
+					// ...last found number will be 'address_2'
+					foreach ($address_exploded as $address_key => $address_value) {
+						if (is_numeric($address_value)) {
+							// Set last index as street number
+							$set_key = $address_key;
+						}
+					}
+
+					// If no number was found, then take last part of address no matter what it is
+					if( $set_key === false ) {
 						$set_key = $address_key;
 					}
-				}
 
-				// If no number was found, then take last part of address no matter what it is
-				if( $set_key === false ) {
-					$set_key = $address_key;
+					// The number is the first part of address 1
+					if( $set_key == 0 ) {
+						// Set "address_2" first, as first part
+						$args['shipping_address']['address_2'] = implode( ' ', array_slice( $address_exploded, 0, 1 ) );
+						// Remove "address_2" from "address_1"
+						$args['shipping_address']['address_1'] = implode( ' ', array_slice( $address_exploded, 1 ) );
+					} else {
+						// Set "address_2" first
+						$args['shipping_address']['address_2'] = implode( ' ', array_slice( $address_exploded, $set_key ) );
+						// Remove "address_2" from "address_1"
+						$args['shipping_address']['address_1'] = implode( ' ', array_slice( $address_exploded, 0 , $set_key ) );
+					}
 				}
-
-				// The number is the first part of address 1
-                if( $set_key == 0 ) {
-                    // Set "address_2" first, as first part
-                    $args['shipping_address']['address_2'] = implode( ' ', array_slice( $address_exploded, 0, 1 ) );
-                    // Remove "address_2" from "address_1"
-                    $args['shipping_address']['address_1'] = implode( ' ', array_slice( $address_exploded, 1 ) );
-                } else {
-                    // Set "address_2" first
-                    $args['shipping_address']['address_2'] = implode( ' ', array_slice( $address_exploded, $set_key ) );
-                    // Remove "address_2" from "address_1"
-				    $args['shipping_address']['address_1'] = implode( ' ', array_slice( $address_exploded, 0 , $set_key ) );
-                }
 			}
 		}
 

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
@@ -464,28 +464,28 @@ class PR_DHL_API_SOAP_Label extends PR_DHL_API_SOAP implements PR_DHL_API_Label 
                     // Break address into pieces by '.'
                     $address_exploded = explode('.', $args['shipping_address']['address_1']);
 					// Check if address 2 empty and its in Germany
-                    if( count($address_exploded) == 1 && 'DE' === $args['shipping_address']['country'] ) {
+	                if ( 1 === count( $address_exploded ) && 'DE' === $args['shipping_address']['country'] ) {
                         throw new Exception(__('Shipping "Address 2" is empty!', 'dhl-for-woocommerce'));
                     }
                 }
 
-				if( count($address_exploded) > 1 ) {
+				if ( count( $address_exploded ) > 1 ) {
 					// Loop through address and set number value only...
 					// ...last found number will be 'address_2'
-					foreach ($address_exploded as $address_key => $address_value) {
-						if (is_numeric($address_value)) {
+					foreach ( $address_exploded as $address_key => $address_value ) {
+						if ( is_numeric( $address_value ) ) {
 							// Set last index as street number
 							$set_key = $address_key;
 						}
 					}
 
 					// If no number was found, then take last part of address no matter what it is
-					if( $set_key === false ) {
+					if( false === $set_key ) {
 						$set_key = $address_key;
 					}
 
 					// The number is the first part of address 1
-					if( $set_key == 0 ) {
+					if( 0 === $set_key ) {
 						// Set "address_2" first, as first part
 						$args['shipping_address']['address_2'] = implode( ' ', array_slice( $address_exploded, 0, 1 ) );
 						// Remove "address_2" from "address_1"

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
@@ -463,12 +463,14 @@ class PR_DHL_API_SOAP_Label extends PR_DHL_API_SOAP implements PR_DHL_API_Label 
                 if( count($address_exploded) == 1 ) {
                     // Break address into pieces by '.'
                     $address_exploded = explode('.', $args['shipping_address']['address_1']);
-					// Check if address 2 empty and its in Germany
+
+					// If no address number and in Germany, return error
 	                if ( 1 === count( $address_exploded ) && 'DE' === $args['shipping_address']['country'] ) {
-                        throw new Exception(__('Shipping "Address 2" is empty!', 'dhl-for-woocommerce'));
+                        throw new Exception(__('Shipping street number is missing!', 'dhl-for-woocommerce'));
                     }
                 }
 
+                // If greater than 1, means there are two parts to the address...otherwise Address 2 is empty which is possible in some countries outside of Germany
 				if ( count( $address_exploded ) > 1 ) {
 					// Loop through address and set number value only...
 					// ...last found number will be 'address_2'

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
@@ -463,8 +463,8 @@ class PR_DHL_API_SOAP_Label extends PR_DHL_API_SOAP implements PR_DHL_API_Label 
                 if( count($address_exploded) == 1 ) {
                     // Break address into pieces by '.'
                     $address_exploded = explode('.', $args['shipping_address']['address_1']);
-
-                    if( count($address_exploded) == 1 ) {
+					// Check if address 2 empty and its in Germany
+                    if( count($address_exploded) == 1 && 'DE' === $args['shipping_address']['country'] ) {
                         throw new Exception(__('Shipping "Address 2" is empty!', 'dhl-for-woocommerce'));
                     }
                 }

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-soap-label.php
@@ -742,7 +742,6 @@ class PR_DHL_API_SOAP_Label extends PR_DHL_API_SOAP implements PR_DHL_API_Label 
 											array(
 												'product' => $this->args['order_details']['dhl_product'],
 												'accountNumber' => $account_number,
-												'accountNumber' => $account_number,
 												'shipmentDate' => $berlin_date->format('Y-m-d'),
 												'ShipmentItem' =>
 													array(


### PR DESCRIPTION
https://wordpress.org/support/topic/shipping-address-2-is-empty-error-message-2