### PR TITLE
fix PHP 8.0 linter warning

### DIFF
--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-auth-rest.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-auth-rest.php
@@ -59,7 +59,7 @@ class PR_DHL_API_Auth_REST {
 	private function __clone() { }
    	
    	// Stopping unserialize of object
-	private function __wakeup() { }
+	public function __wakeup() { }
 
 	public static function get_instance( ) {
 


### PR DESCRIPTION
https://wordpress.org/support/topic/trivial-php-8-0-linter-warning-magic-method-must-have-public-visibility/
