### PR TITLE
Updating TCPDF version

### DIFF
--- a/pr-dhl-woocommerce/lib/PDFMerger/tcpdf/include/tcpdf_static.php
+++ b/pr-dhl-woocommerce/lib/PDFMerger/tcpdf/include/tcpdf_static.php
@@ -55,7 +55,7 @@ class TCPDF_STATIC {
 	 * Current TCPDF version.
 	 * @private static
 	 */
-	private static $tcpdf_version = '6.2.12';
+	private static $tcpdf_version = '6.2.22';
 
 	/**
 	 * String alias for total number of pages.


### PR DESCRIPTION
6.2.12 is susceptible to remote code execution in the TCPDF PHP library. Updating it to 6.2.22 should fix the issue.