### PR TITLE
Add/sandbox developer account

### DIFF
--- a/pr-dhl-woocommerce/assets/js/pr-dhl-paket-settings.js
+++ b/pr-dhl-woocommerce/assets/js/pr-dhl-paket-settings.js
@@ -7,6 +7,21 @@ jQuery( document ).ready(function(){
 		DHLSandboxEnabled( jQuery( this ) );
 	});
 
+	const api_mode = jQuery('#woocommerce_pr_dhl_paket_dhl_default_api');
+	const developer_account = jQuery('#woocommerce_pr_dhl_paket_dhl_developer_account');
+	DHLAPIModeChanged(api_mode);
+
+	function setupEventListeners() {
+		api_mode.on('change', () => {
+			DHLAPIModeChanged(api_mode);
+		});
+
+		developer_account.on('change', () => {
+			DHLAPIModeChanged(api_mode);
+		});
+	}
+	setupEventListeners();
+
 	var logo_checkbox = jQuery('#woocommerce_pr_dhl_paket_dhl_add_logo');
 	DHLLogoEnabled( logo_checkbox );
 
@@ -41,6 +56,9 @@ function DHLSandboxEnabled( sandbox_checkbox ){
 	var api_sandbox_password 	= jQuery('#woocommerce_pr_dhl_paket_dhl_api_sandbox_pwd');
 	var tr_sandbox_username 	= api_sandbox_username.closest('tr');
 	var tr_sandbox_password 	= api_sandbox_password.closest('tr');
+	var api_mode 				= jQuery('#woocommerce_pr_dhl_paket_dhl_default_api');
+	var developer_account 		= jQuery('#woocommerce_pr_dhl_paket_dhl_developer_account');
+
 
 	if( sandbox_checkbox.prop('checked') == true ){
 
@@ -52,15 +70,61 @@ function DHLSandboxEnabled( sandbox_checkbox ){
 		api_settings_password.prop('readonly', true );
 		account_number.prop('readonly', true );
 
+		if ( 'rest-api' === api_mode.val() ) {
+			developer_account.closest('tr').show();
+
+			if ( true !== developer_account.prop('checked') ) {
+				return;
+			}
+		}
+
 		tr_sandbox_username.show();
 		tr_sandbox_password.show();
+
 	}else{
+		if ( 'rest-api' === api_mode.val() ) {
+			developer_account.closest('tr').hide();
+		}
+
 		api_settings_username.prop('readonly', false );
 		api_settings_password.prop('readonly', false );
 		account_number.prop('readonly', false );
 
 		tr_sandbox_username.hide();
 		tr_sandbox_password.hide();
+	}
+}
+
+function DHLAPIModeChanged(api_mode) {
+	const developer_account = jQuery('#woocommerce_pr_dhl_paket_dhl_developer_account');
+	const sandbox_checkbox = jQuery('#woocommerce_pr_dhl_paket_dhl_sandbox');
+
+	const tr_sandbox_username = jQuery('#woocommerce_pr_dhl_paket_dhl_api_sandbox_user').closest('tr');
+	const tr_sandbox_password = jQuery('#woocommerce_pr_dhl_paket_dhl_api_sandbox_pwd').closest('tr');
+
+	function toggleElement(element, condition) {
+		element.closest('tr').toggle(condition);
+	}
+
+	const isRestApiMode = 'rest-api' === api_mode.val();
+	const isSandboxChecked = sandbox_checkbox.prop('checked');
+	const isDeveloperAccountChecked = developer_account.prop('checked');
+
+	// Hide or show developer_account based on conditions
+	toggleElement(developer_account, isRestApiMode && isSandboxChecked);
+
+	if (isRestApiMode && isSandboxChecked) {
+		// If developer_account checkbox is checked, show username and password fields
+		toggleElement(tr_sandbox_username, isDeveloperAccountChecked);
+		toggleElement(tr_sandbox_password, isDeveloperAccountChecked);
+	} else if (!isRestApiMode && isSandboxChecked) {
+		// Always show username and password fields if not in rest-api mode but sandbox is checked
+		toggleElement(tr_sandbox_username, true);
+		toggleElement(tr_sandbox_password, true);
+	} else {
+		// Hide username and password fields otherwise
+		toggleElement(tr_sandbox_username, false);
+		toggleElement(tr_sandbox_password, false);
 	}
 }
 

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -441,6 +441,11 @@ class Client extends API_Client {
 	protected function get_response_error_message( Response $response ) {
 		$multiple_errors_list = array();
 
+		// Handle sandbox error
+		if ( isset( $response->body->detail ) ) {
+			return $response->body->detail;
+		}
+
 		if ( ! is_array( $response->body->items ) ) {
 			return  $response->body;
 		}

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-paket.php
@@ -173,6 +173,14 @@ class PR_DHL_WC_Method_Paket extends WC_Shipping_Method {
 				'description'       => __( 'Please, tick here if you want to test the plug-in installation against the DHL Sandbox Environment. Labels generated via Sandbox cannot be used for shipping and you need to enter your client ID and client secret for the Sandbox environment instead of the ones for production!', 'dhl-for-woocommerce' ),
 				'desc_tip'          => true,
 			),
+			'dhl_developer_account' => array(
+				'title'             => __( 'DHL developer account', 'dhl-for-woocommerce' ),
+				'type'              => 'checkbox',
+				'label'             => __( 'I have developer account', 'dhl-for-woocommerce' ),
+				'default'           => 'no',
+				'description'       => __( 'If you don\'t have DHL developer account and you want to create labels in the sandbox, we will use DHL testsuite credentials.', 'dhl-for-woocommerce' ),
+				'desc_tip'          => true,
+			),
 			'dhl_api_sandbox_user' => array(
 				'title'             => __( 'Sandbox Username', 'dhl-for-woocommerce' ),
 				'type'              => 'text',

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-paket.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-paket.php
@@ -208,22 +208,20 @@ class PR_DHL_API_REST_Paket extends PR_DHL_API {
 	 */
 	public function get_customer_portal_login() {
 		$is_sandbox = $this->get_setting( 'dhl_sandbox' );
-		$is_sandbox = filter_var($is_sandbox, FILTER_VALIDATE_BOOLEAN);
+		$is_sandbox = filter_var( $is_sandbox, FILTER_VALIDATE_BOOLEAN );
 		if ( $is_sandbox ) {
-			$sandbox = $this->sandbox_info_customer_portal();
-			return array(
-				'username' => $sandbox['username'],
-				'pass' => $sandbox['pass'],
-			);
-			// return array(
-			// 	'username' => $this->get_setting('dhl_api_sandbox_user'),
-			// 	'pass' => $this->get_setting('dhl_api_sandbox_pwd'),
-			// );
+			$sandbox               = $this->sandbox_info_customer_portal();
+			$has_developer_account = $this->get_setting( 'dhl_developer_account', 'no' );
+			$has_developer_account = filter_var( $has_developer_account, FILTER_VALIDATE_BOOLEAN );
 
+			return array(
+				'username' => $has_developer_account ? $this->get_setting( 'dhl_api_sandbox_user' ) : $sandbox['username'],
+				'pass'     => $has_developer_account ? $this->get_setting( 'dhl_api_sandbox_pwd' ) : $sandbox['pass'],
+			);
 		} else {
 			return array(
 				'username' => $this->get_setting( 'dhl_api_user' ),
-				'pass' => $this->get_setting( 'dhl_api_pwd' ),
+				'pass'     => $this->get_setting( 'dhl_api_pwd' ),
 			);
 		}
 	}

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-parcel-de.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-parcel-de.php
@@ -591,7 +591,7 @@ class PR_DHL_API_REST_Parcel_DE extends PR_DHL_API_REST_Paket {
 	 */
 	public function sandbox_info_customer_portal(){
 		return array(
-			'username' 	=> '3333333333_01',
+			'username' 	=> 'sandy_sandbox',
 			'pass' 		=> 'pass',
 			'account_no'=> '3333333333',
 		);

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -7,7 +7,7 @@
  * Author URI: http://dhl.com/
  * Text Domain: dhl-for-woocommerce
  * Domain Path: /lang
- * Version: 3.5.5
+ * Version: 3.5.6
  * Tested up to: 6.3
  * WC requires at least: 3.0
  * WC tested up to: 8.1
@@ -38,7 +38,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 class PR_DHL_WC {
 
-	private $version = "3.5.5";
+	private $version = "3.5.6";
 
 	/**
 	 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -5,7 +5,7 @@ Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, W
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.3
-Stable tag: 3.5.5
+Stable tag: 3.5.6
 WC requires at least: 3.0
 WC tested up to: 8.1
 License: GPLv2 or later
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+
+= 3.5.6 =
+* DHL Paket: Add Parcel-DE Rest-API sandbox default account.
 
 = 3.5.5 =
 * Fix Parcel-DE Rest-API production link.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -5,7 +5,7 @@ Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, W
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.3
-Stable tag: 3.5.5
+Stable tag: 3.5.6
 WC requires at least: 3.0
 WC tested up to: 8.1
 License: GPLv2 or later
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+
+= 3.5.6 =
+* DHL Paket: Add Parcel-DE Rest-API sandbox default account.
 
 = 3.5.5 =
 * Fix Parcel-DE Rest-API production link.


### PR DESCRIPTION
I added "DHL developer account" checkbox, it will appear only if the Used API is Rest
the customer can check this field if he have [DHL developer portal account](https://developer.dhl.com/), otherwise the plugin will use the DHL testsuite credentials

![image](https://github.com/shadimanna/dhl-logistic-services-for-woocommerce/assets/19236737/e2441515-1f2e-4e88-9aab-d85c30733b3f)

![image](https://github.com/shadimanna/dhl-logistic-services-for-woocommerce/assets/19236737/e63a77f5-90e1-473c-b818-d5f7001b9895)
