### PR TITLE
Fix myaccount issue - 403 response

### DIFF
--- a/pr-dhl-woocommerce/includes/REST_API/Drivers/WP_API_Driver.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Drivers/WP_API_Driver.php
@@ -33,11 +33,12 @@ class WP_API_Driver implements API_Driver_Interface {
 		$response = wp_remote_request(
 			$request->url,
 			array(
-				'method'  => $this->get_request_type( $request ),
-				'body'    => $request->body,
-				'headers' => $request->headers,
-				'cookies' => $request->cookies,
-                'timeout' => self::WP_REQUEST_TIMEOUT,
+				'method'     => $this->get_request_type( $request ),
+				'body'       => $request->body,
+				'headers'    => $request->headers,
+				'cookies'    => $request->cookies,
+				'timeout'    => self::WP_REQUEST_TIMEOUT,
+				'user-agent' => 'Progressus/DHL Plugin',
 			)
 		);
 

--- a/pr-dhl-woocommerce/includes/REST_API/Drivers/WP_API_Driver.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Drivers/WP_API_Driver.php
@@ -38,7 +38,7 @@ class WP_API_Driver implements API_Driver_Interface {
 				'headers'    => $request->headers,
 				'cookies'    => $request->cookies,
 				'timeout'    => self::WP_REQUEST_TIMEOUT,
-				'user-agent' => 'Progressus/DHL Plugin',
+				'user-agent' => 'WooCommerce/'. WC_VERSION . ' (WordPress/'. get_bloginfo('version') . ') DHL-plug-in/' . PR_DHL_VERSION,
 			)
 		);
 

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -7,10 +7,11 @@
  * Author URI: http://dhl.com/
  * Text Domain: dhl-for-woocommerce
  * Domain Path: /lang
- * Version: 3.6.5
- * Tested up to: 6.5
+ * Version: 3.6.4
+ * Tested up to: 6.3
  * WC requires at least: 3.0
- * WC tested up to: 8.7
+ * WC tested up to: 8.4
+ * Requires at least: 4.6
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,7 +38,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 class PR_DHL_WC {
 
-	private $version = "3.6.5";
+	private $version = "3.6.4";
 
 	/**
 	 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -7,11 +7,10 @@
  * Author URI: http://dhl.com/
  * Text Domain: dhl-for-woocommerce
  * Domain Path: /lang
- * Version: 3.6.4
- * Tested up to: 6.3
+ * Version: 3.6.5
+ * Tested up to: 6.5
  * WC requires at least: 3.0
- * WC tested up to: 8.4
- * Requires at least: 4.6
+ * WC tested up to: 8.7
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,7 +37,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 class PR_DHL_WC {
 
-	private $version = "3.6.4";
+	private $version = "3.6.5";
 
 	/**
 	 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -7,7 +7,7 @@
  * Author URI: http://dhl.com/
  * Text Domain: dhl-for-woocommerce
  * Domain Path: /lang
- * Version: 3.6.4
+ * Version: 3.6.5
  * Tested up to: 6.5
  * Requires Plugins: woocommerce
  * WC requires at least: 3.0
@@ -38,7 +38,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 class PR_DHL_WC {
 
-	private $version = "3.6.4";
+	private $version = "3.6.5";
 
 	/**
 	 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -4,10 +4,10 @@ Donate link:
 Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, Woocom, Woo Commerce, Shipping, shiping, label creation, label printing, DHL Paket
 Requires at least: 4.6
 Requires PHP: 5.6
-Tested up to: 6.3
-Stable tag: 3.6.2
+Tested up to: 6.5
+Stable tag: 3.6.5
 WC requires at least: 3.0
-WC tested up to: 8.4
+WC tested up to: 8.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,6 +75,15 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+= 3.6.5 =
+* DHL Paket: Fix Get Account Settings error 403
+
+= 3.6.4 =
+* DHL Paket: Fix REST API customs doc merged with label
+* DHL Paket: Fix "Endorsement" warning
+
+= 3.6.3 =
+* DHL Paket: Fix HPOS compatibility with bulk create labels
 
 = 3.6.2 =
 * DHL Paket: Settings is empty on WooCommerce version 8.4.0

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -4,10 +4,10 @@ Donate link:
 Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, Woocom, Woo Commerce, Shipping, shiping, label creation, label printing, DHL Paket
 Requires at least: 4.6
 Requires PHP: 5.6
-Tested up to: 6.5
-Stable tag: 3.6.5
+Tested up to: 6.3
+Stable tag: 3.6.2
 WC requires at least: 3.0
-WC tested up to: 8.7
+WC tested up to: 8.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,15 +75,6 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
-= 3.6.5 =
-* DHL Paket: Fix Get Account Settings error 403
-
-= 3.6.4 =
-* DHL Paket: Fix REST API customs doc merged with label
-* DHL Paket: Fix "Endorsement" warning
-
-= 3.6.3 =
-* DHL Paket: Fix HPOS compatibility with bulk create labels
 
 = 3.6.2 =
 * DHL Paket: Settings is empty on WooCommerce version 8.4.0

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -5,7 +5,7 @@ Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, W
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.5
-Stable tag: 3.6.4
+Stable tag: 3.6.5
 Requires Plugins: woocommerce
 WC requires at least: 3.0
 WC tested up to: 8.7
@@ -76,6 +76,16 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+= 3.6.5 =
+* WordPress 6.5 compatibility.
+* DHL Paket: Fix Get Account Settings - Error 403
+
+= 3.6.4 =
+* DHL Paket: Fix REST API customs doc merged with label
+* DHL Paket: Fix "Endorsement" warning
+
+= 3.6.3 =
+* DHL Paket: Fix HPOS compatibility with bulk create labels
 
 = 3.6.2 =
 * DHL Paket: Settings is empty on WooCommerce version 8.4.0

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -5,7 +5,7 @@ Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, W
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.5
-Stable tag: 3.6.4
+Stable tag: 3.6.5
 Requires Plugins: woocommerce
 WC requires at least: 3.0
 WC tested up to: 8.7
@@ -76,6 +76,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+= 3.6.5 =
+* WordPress 6.5 compatibility.
+* DHL Paket: Fix Get Account Settings - Error 403
 
 = 3.6.4 =
 * DHL Paket: Fix REST API customs doc merged with label

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -4,10 +4,10 @@ Donate link:
 Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, Woocom, Woo Commerce, Shipping, shiping, label creation, label printing, DHL Paket
 Requires at least: 4.6
 Requires PHP: 5.6
-Tested up to: 6.3
-Stable tag: 3.6.4
+Tested up to: 6.5
+Stable tag: 3.6.5
 WC requires at least: 3.0
-WC tested up to: 8.4
+WC tested up to: 8.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,6 +75,8 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+= 3.6.5 =
+* DHL Paket: Fix Get Account Settings error 403
 
 = 3.6.4 =
 * DHL Paket: Fix REST API customs doc merged with label

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -4,10 +4,10 @@ Donate link:
 Tags: DPDHL, original DHL, DHL, DHL eCommerce, DHL Paket Germany, WooCommerce, Woocom, Woo Commerce, Shipping, shiping, label creation, label printing, DHL Paket
 Requires at least: 4.6
 Requires PHP: 5.6
-Tested up to: 6.5
-Stable tag: 3.6.5
+Tested up to: 6.3
+Stable tag: 3.6.4
 WC requires at least: 3.0
-WC tested up to: 8.7
+WC tested up to: 8.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -75,8 +75,6 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
-= 3.6.5 =
-* DHL Paket: Fix Get Account Settings error 403
 
 = 3.6.4 =
 * DHL Paket: Fix REST API customs doc merged with label


### PR DESCRIPTION
i found out that adding 'user-agent' to the WP_API_Driver's send function will fix it, I think DHL block requests that comes with default WordPress user agent (tested by postman and blocked)
maybe they blocked WordPress agent or they don't accept ";" on it (I also tested it and found that when i remove it it works!)
