### PR TITLE
fix escape tracking_link

### DIFF
--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -402,7 +402,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				$tracking_note = $this->shipping_dhl_settings['dhl_tracking_note_txt'];
 			} else {
 				/* translators: %s is the tracking link */
-				$tracking_note = sprintf( esc_html__( '%s Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ), $this->service );
+				$tracking_note = sprintf( __( '%s Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ), $this->service );
 			}
 
 			$tracking_link = $this->get_tracking_link( $order_id );

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-deutsche-post.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-deutsche-post.php
@@ -240,12 +240,12 @@ class PR_DHL_WC_Method_Deutsche_Post extends WC_Shipping_Method {
 			'dhl_tracking_note_txt'   => array(
 				'title'       => esc_html__( 'Tracking Note', 'dhl-for-woocommerce' ),
 				'type'        => 'textarea',
-				'description' => esc_html__(
+				'description' => __(
 					'Set the custom text when adding the tracking number to the order notes. {tracking-link} is where the tracking number will be set.',
 					'dhl-for-woocommerce'
 				),
 				'desc_tip'    => false,
-				'default'     => esc_html__( 'Deutsche Post Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
+				'default'     => __( 'Deutsche Post Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
 			),
 		);
 

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-ecomm.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-ecomm.php
@@ -277,9 +277,9 @@ if ( ! class_exists( 'PR_DHL_Ecomm_Shipping_Method' ) ) :
 				'dhl_tracking_note_txt' => array(
 					'title'       => esc_html__( 'Tracking Note', 'dhl-for-woocommerce' ),
 					'type'        => 'textarea',
-					'description' => esc_html__( 'Set the custom text when adding the tracking number to the order notes. {tracking-link} is where the tracking number will be set.', 'dhl-for-woocommerce' ),
+					'description' => __( 'Set the custom text when adding the tracking number to the order notes. {tracking-link} is where the tracking number will be set.', 'dhl-for-woocommerce' ),
 					'desc_tip'    => false,
-					'default'     => esc_html__( 'DHL Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
+					'default'     => __( 'DHL Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
 				),
 				'dhl_api'               => array(
 					'title'       => esc_html__( 'API Settings', 'dhl-for-woocommerce' ),

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-ecs-asia.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-ecs-asia.php
@@ -252,9 +252,9 @@ if ( ! class_exists( 'PR_DHL_WC_Method_eCS_Asia' ) ) :
 				'dhl_tracking_note_txt'            => array(
 					'title'       => esc_html__( 'Tracking Note', 'dhl-for-woocommerce' ),
 					'type'        => 'textarea',
-					'description' => esc_html__( 'Set the custom text when adding the tracking number to the order notes. {tracking-link} is where the tracking number will be set.', 'dhl-for-woocommerce' ),
+					'description' => __( 'Set the custom text when adding the tracking number to the order notes. {tracking-link} is where the tracking number will be set.', 'dhl-for-woocommerce' ),
 					'desc_tip'    => false,
-					'default'     => esc_html__( 'DHL Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
+					'default'     => __( 'DHL Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
 				),
 				'dhl_api'                          => array(
 					'title'       => esc_html__( 'API Settings', 'dhl-for-woocommerce' ),

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-paket.php
@@ -539,9 +539,9 @@ if ( ! class_exists( 'PR_DHL_WC_Method_Paket' ) ) :
 				'dhl_tracking_note_txt'             => array(
 					'title'       => esc_html__( 'Tracking Text', 'dhl-for-woocommerce' ),
 					'type'        => 'textarea',
-					'description' => esc_html__( 'Set the custom text when adding the tracking number to the order notes or completed email. {tracking-link} is where the tracking number will be set.', 'dhl-for-woocommerce' ),
+					'description' => __( 'Set the custom text when adding the tracking number to the order notes or completed email. {tracking-link} is where the tracking number will be set.', 'dhl-for-woocommerce' ),
 					'desc_tip'    => false,
-					'default'     => esc_html__( 'DHL Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
+					'default'     => __( 'DHL Tracking Number: {tracking-link}', 'dhl-for-woocommerce' ),
 				),
 				'dhl_add_tracking_info_completed'   => array(
 					'title'       => esc_html__( 'Tracking Email', 'dhl-for-woocommerce' ),


### PR DESCRIPTION
Related [task](https://app.clickup.com/t/868apbyw8)
I've removed `esc_html` from all text containing {tracking_link} to prevent this issue from occurring in all locations.