### PR TITLE
Fix wrong Postal charges / Fees value

### DIFF
--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -405,7 +405,7 @@ class Client extends API_Client {
 				$array[ $k ] = $this->unset_empty_values( $v );
 			}
 
-			if ( empty( $v ) ) {
+			if ( empty( $v ) && ! is_numeric( $v ) ) {
 				unset( $array[ $k ] );
 			}
 		}

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -269,6 +269,9 @@ class Client extends API_Client {
 			$item_description .= $item['itemDescription'];
 		}
 
+		$additional_fee = floatval( $request_info->args['order_details']['additional_fee'] );
+		$shipping_fee   = floatval( $request_info->args['order_details']['shipping_fee'] );
+
 		return array(
 			'invoiceNo'         => $request_info->args['order_details']['invoice_num'],
 			'exportType'        => apply_filters( 'pr_shipping_dhl_paket_label_shipment_export_type', 'COMMERCIAL_GOODS' ),
@@ -276,7 +279,7 @@ class Client extends API_Client {
 			'items'             => $this->prepare_items( $request_info ),
 			'postalCharges'     => array(
 				'currency' => $request_info->args['order_details']['currency'],
-				'value'    => $request_info->args['order_details']['total_value'],
+				'value'    => $additional_fee + $shipping_fee,
 			),
 		);
 	}

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -9,11 +9,11 @@
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: dhl-for-woocommerce
  * Domain Path: /lang
- * Version: 3.7.6
+ * Version: 3.7.7
  * Tested up to: 6.7
  * Requires Plugins: woocommerce
  * WC requires at least: 3.0
- * WC tested up to: 9.3
+ * WC tested up to: 9.5
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +39,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 	class PR_DHL_WC {
 
-		private $version = '3.7.6';
+		private $version = '3.7.7';
 
 		/**
 		 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -76,6 +76,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.7.7 =
+* DHL Paket: Fix Customs Postal Charges value.
+
 = 3.7.6 =
 * DHL Paket: Fix "File cannot be saved" using SOAP API.
 

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -5,10 +5,10 @@ Tags: DPDHL, DHL, DHL eCommerce, DHL Paket Germany, Shipping
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.7
-Stable tag: 3.7.6
+Stable tag: 3.7.7
 Requires Plugins: woocommerce
 WC requires at least: 3.0
-WC tested up to: 9.3
+WC tested up to: 9.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -76,6 +76,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.7.7 =
+* DHL Paket: Fix Customs Postal Charges value.
+
 = 3.7.6 =
 * DHL Paket: Fix "File cannot be saved" using SOAP API.
 

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -5,10 +5,10 @@ Tags: DPDHL, DHL, DHL eCommerce, DHL Paket Germany, Shipping
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 6.7
-Stable tag: 3.7.6
+Stable tag: 3.7.7
 Requires Plugins: woocommerce
 WC requires at least: 3.0
-WC tested up to: 9.3
+WC tested up to: 9.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fix wrong Postal charges / Fees value instead of sending order total.

### How to test the changes in this Pull Request:

1. Create a new order with international shipping address.
2. Try to create a shipping label for this order.
3. Check the created label, you will find **Customs Declaration CN23** file on it, check `Postal charges / Fees` it should be the shipping/additional fees value.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix Customs Postal Charges value.
