### PR TITLE
Update api for DHL Kleinpaket instead of Warenpost

### DIFF
--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-paket.php
@@ -507,7 +507,7 @@ if ( ! class_exists( 'PR_DHL_WC_Method_Paket' ) ) :
 						'910-300-410'    => 'Laser printer 103 x 150 mm',
 						'910-300-300'    => 'Laser printer 105 x 148 mm',
 						'910-300-300-oZ' => 'Laser printer 105 x 148 mm (without additional labels)',
-						'100x70mm'       => '100 x 70 mm (only for Warenpost)',
+						'100x70mm'       => '100 x 70 mm (only for DHL Kleinpaket)',
 					),
 					'default'     => '910-300-700',
 					'class'       => 'wc-enhanced-select',

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-paket.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-paket.php
@@ -185,7 +185,7 @@ class PR_DHL_API_Paket extends PR_DHL_API {
 		$germany_dom = array(
 			'V01PAK'  => esc_html__( 'DHL Paket', 'dhl-for-woocommerce' ),
 			'V01PRIO' => esc_html__( 'DHL Paket PRIO', 'dhl-for-woocommerce' ),
-			'V62WP'   => esc_html__( 'DHL Warenpost National', 'dhl-for-woocommerce' ),
+			'V62KP'   => esc_html__( 'DHL Kleinpaket', 'dhl-for-woocommerce' ),
 		);
 
 		$dhl_prod_dom = array();

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-paket.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-paket.php
@@ -304,7 +304,7 @@ class PR_DHL_API_REST_Paket extends PR_DHL_API {
 		$germany_dom = array(
 			'V01PAK'  => esc_html__( 'DHL Paket', 'dhl-for-woocommerce' ),
 			'V01PRIO' => esc_html__( 'DHL Paket PRIO', 'dhl-for-woocommerce' ),
-			'V62WP'   => esc_html__( 'DHL Warenpost National', 'dhl-for-woocommerce' ),
+			'V62KP'   => esc_html__( 'DHL Kleinpaket', 'dhl-for-woocommerce' ),
 		);
 
 		$dhl_prod_dom = array();


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.Create an order
2. Change your contract information in plugin settings from Warenpost to Dhl Kleinpaket
3.Generate a label with DHL Kleinpaket as your preferred shipping method

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
I have changed 3 files:
pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-paket.php
pr-dhl-woocommerce/includes/class-pr-dhl-wc-method-paket.php
pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-paket.php
Updated the connection to use DHL Kleinpaket based on DHL documentation.
![image](https://github.com/user-attachments/assets/9a076b32-eef4-43de-b2d4-d63d0480036d)
