### PR TITLE
Fix label status for international addresses

### DIFF
--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
@@ -994,7 +994,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Paket' ) ) :
 
 			$status_setting = str_replace( 'wc-', '', $this->shipping_dhl_settings['dhl_create_label_on_status'] );
 			if ( $status_setting == $status_to ) {
-				$this->process_bulk_actions( 'pr_dhl_create_labels', array( $order_id ), 1 );
+				$this->process_bulk_actions( 'pr_dhl_create_labels', array( $order_id ) );
 			}
 		}
 

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -76,6 +76,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.7.9 =
+* DHL Paket: Fixed automatic label creation failure for international shipments on status change.
+
 = 3.7.8 =
 * DHL Paket: Add DHL Kleinpaket product.
 

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -76,6 +76,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.7.9 =
+* DHL Paket: Fixed automatic label creation failure for international shipments on status change.
+
 = 3.7.8 =
 * DHL Paket: Add DHL Kleinpaket product.
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you tested both blocks/non-blocks cart/checkout?
* [x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Go to Shipping Label Settings in the plugin
2. Set Create Label on Status to the desired status 
3. Create a new order
4. Change the order to the same status you configured.
5. Confirm the label is automatically created.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Related task
https://app.clickup.com/t/868bv9m8h