### PR TITLE
Fix PHP Fatal error: Uncaught Error: Class “PR\DHL\REST_API\Drivers\WP_API_Driver” not found

### DIFF
--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -181,13 +181,13 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 		 */
 		public function includes() {
 			// Auto loader class
-			include_once 'includes/class-pr-dhl-autoloader.php';
+			include_once PR_DHL_PLUGIN_DIR_PATH . '/includes/class-pr-dhl-autoloader.php';
 			// Load abstract classes
-			include_once 'includes/abstract-pr-dhl-wc-order.php';
-			include_once 'includes/abstract-pr-dhl-wc-product.php';
+			include_once PR_DHL_PLUGIN_DIR_PATH . '/includes/abstract-pr-dhl-wc-order.php';
+			include_once PR_DHL_PLUGIN_DIR_PATH . '/includes/abstract-pr-dhl-wc-product.php';
 
 			// Composer autoloader
-			include_once 'vendor/autoload.php';
+			include_once PR_DHL_PLUGIN_DIR_PATH . '/vendor/autoload.php';
 		}
 
 		/**

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -9,13 +9,13 @@
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: dhl-for-woocommerce
  * Domain Path: /lang
- * Version: 3.8.0
+ * Version: 3.8.1
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * Requires at least: 6.5
  * Tested up to: 6.7
- * WC requires at least: 9.3
- * WC tested up to: 9.5
+ * WC requires at least: 9.4
+ * WC tested up to: 9.6
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 	class PR_DHL_WC {
 
-		private $version = '3.8.0';
+		private $version = '3.8.1';
 
 		/**
 		 * Instance to call certain functions globally within the plugin

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -1,13 +1,13 @@
 === DHL Shipping Germany for WooCommerce ===
 Contributors: DHL, shadim, utzfu
 Tags: DPDHL, DHL, DHL eCommerce, DHL Paket Germany, Shipping
-Stable tag: 3.8.0
+Stable tag: 3.8.1
 Requires Plugins: woocommerce
 Requires PHP: 7.4
 Requires at least: 6.5
 Tested up to: 6.7
-WC requires at least: 9.3
-WC tested up to: 9.5
+WC requires at least: 9.4
+WC tested up to: 9.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -74,6 +74,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 
 == Changelog ==
+
+= 3.8.1 =
+* Fix: PHP fatal error related to class loading conflicts in environments with multiple active autoloaders.
 
 = 3.8.0 =
 * Drop old WooCommerce versions support.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.8.1 =
+* Fix: PHP fatal error related to class loading conflicts in environments with multiple active autoloaders.
+
 = 3.8.0 =
 * Drop old WooCommerce versions support.
 * DHL Paket: Fix tracking link in "Completed Order" emails.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -1,13 +1,13 @@
 === DHL Shipping Germany for WooCommerce ===
 Contributors: DHL, shadim, utzfu
 Tags: DPDHL, DHL, DHL eCommerce, DHL Paket Germany, Shipping
-Stable tag: 3.8.0
+Stable tag: 3.8.1
 Requires Plugins: woocommerce
 Requires PHP: 7.4
 Requires at least: 6.5
 Tested up to: 6.7
-WC requires at least: 9.3
-WC tested up to: 9.5
+WC requires at least: 9.4
+WC tested up to: 9.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://wordpress.org/support/topic/uncaught-error-class-prdhlrest_apidriverswp_api_driver-not-found/ .

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Fix: PHP fatal error related to class loading conflicts in environments with multiple active autoloaders.

