### PR TITLE
Fix Pickup request popup when HPOS enabled

### DIFF
--- a/pr-dhl-woocommerce/assets/js/pr-dhl-paket-order-bulk.js
+++ b/pr-dhl-woocommerce/assets/js/pr-dhl-paket-order-bulk.js
@@ -1,14 +1,12 @@
 ( function( $ ) {
+	var posts_filter = jQuery( '#posts-filter, #wc-orders-filter' );
 
 	var wc_dhl_paket_order_bulk = {
 		// init Class
 		init: function() {
-			$( '#posts-filter' )
-				.on( 'change', '#bulk-action-selector-top', this.toggle_paket_pickup_modal );
-			$( '#posts-filter' )
-				.on( 'change', '#bulk-action-selector-bottom', this.toggle_paket_pickup_modal );
-			$( '#posts-filter' )
-				.on( 'click', '.button.action', this.disable_submit_button );
+			posts_filter.on( 'change', '#bulk-action-selector-top', this.toggle_paket_pickup_modal );
+			posts_filter.on( 'change', '#bulk-action-selector-bottom', this.toggle_paket_pickup_modal );
+			posts_filter.on( 'click', '.button.action', this.disable_submit_button );
 
 			$( '#dhl-paket-action-request-pickup' )
 				.on( 'change', '[name=pr_dhl_request_pickup_modal]', this.show_hide_request_pickup_date_asap );
@@ -25,7 +23,7 @@
 
 			if ( 'pr_dhl_create_labels' === bulkdropdown.val() || 'pr_dhl_delete_labels' === bulkdropdown.val() ) {
 				jQuery( this ).prop( 'disabled', true );
-				jQuery( '#posts-filter' ).submit();
+				posts_filter.submit();
 			}
 		},
 
@@ -34,7 +32,6 @@
 
 			var value 		= jQuery( this ).val();
 			var title 		= jQuery(':selected', this ).text();
-			var post_form 	= jQuery( this ).parents('#posts-filter');
 
 			if( 'pr_dhl_request_pickup' == value ){
 
@@ -70,16 +67,12 @@
 
 			var pickup_type 		= elemModal.find( 'input[name=pr_dhl_request_pickup_modal]:checked' ).val();
 			var pickup_date 		= elemModal.find( 'input[name=pr_dhl_request_pickup_date_modal]' ).val();
-			//var transportation_type = elemModal.find( 'select[name=pr_dhl_request_pickup_transportation_type] :selected' ).val();
 
-			jQuery('#posts-filter [name=dhlpickup]').val(pickup_type);
-			jQuery('#posts-filter [name=dhlpickup_d]').val(pickup_date);
-			//jQuery('#posts-filter [name=dhlpickup_t]').val(transportation_type);
-
-			//console.log('type: '+ pickup_type + ' | date: ' + pickup_date+ ' | transportation_type: ' + transportation_type);
+			jQuery('#posts-filter [name=dhlpickup], #wc-orders-filter [name=dhlpickup]').val(pickup_type);
+			jQuery('#posts-filter [name=dhlpickup_d],#wc-orders-filter [name=dhlpickup_d]').val(pickup_date);
 
 			//Submit bulk action
-			jQuery('#posts-filter #doaction').first().click();
+			jQuery('#posts-filter #doaction, #wc-orders-filter #doaction').first().click();
 
 		}
 	};

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
@@ -1251,23 +1251,29 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Paket' ) ) :
 			return $redirect_url;
 		}
 
-		public function enqueue_order_list_assets() {
-			global $pagenow, $typenow;
+	  public function enqueue_order_list_assets() {
+		  global $typenow, $pagenow, $current_screen;
 
-			if ( 'shop_order' === $typenow && 'edit.php' === $pagenow ) {
-				// Enqueue the assets
-				wp_enqueue_style( 'thickbox' );
-				wp_enqueue_script( 'thickbox' );
+		  $is_orders_list = API_Utils::is_HPOS()
+			  ? ( wc_get_page_screen_id( 'shop-order' ) === $current_screen->id && 'admin.php' === $pagenow )
+			  : ( 'shop_order' === $typenow && 'edit.php' === $pagenow );
 
-				wp_enqueue_script(
-					'wc-shipment-dhl-paket-order-bulk-js',
-					PR_DHL_PLUGIN_DIR_URL . '/assets/js/pr-dhl-paket-order-bulk.js',
-					array(),
-					PR_DHL_VERSION,
-					true
-				);
-			}
-		}
+		  if ( ! $is_orders_list ) {
+			  return;
+		  }
+
+		  // Enqueue the assets
+		  wp_enqueue_style( 'thickbox' );
+		  wp_enqueue_script( 'thickbox' );
+
+		  wp_enqueue_script(
+			  'wc-shipment-dhl-paket-order-bulk-js',
+			  PR_DHL_PLUGIN_DIR_URL . '/assets/js/pr-dhl-paket-order-bulk.js',
+			  array(),
+			  PR_DHL_VERSION,
+			  true
+		  );
+	  }
 
 		public function bulk_actions_fields_pickup_request() {
 			global $typenow, $pagenow, $current_screen;

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.8.1 =
+* DHL Paket: Pickup request popup when HPOS enabled.
+
 = 3.8.0 =
 * Drop old WooCommerce versions support.
 * DHL Paket: Fix tracking link in "Completed Order" emails.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.8.1 =
+* DHL Paket: Pickup request popup when HPOS enabled.
+
 = 3.8.0 =
 * Drop old WooCommerce versions support.
 * DHL Paket: Fix tracking link in "Completed Order" emails.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Enable HPOS
2. Go to orders list, select an order and try to request a pick up
3. It should display a popup
<img width="414" alt="image" src="https://github.com/user-attachments/assets/e47cab39-c2be-4e60-9928-879390cae7a2" />


### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

* DHL Paket: Pickup request popup when HPOS enabled.
