### PR TITLE
remove seconds part from open and close time

### DIFF
--- a/pr-dhl-woocommerce/assets/js/pr-dhl-checkout-frontend.js
+++ b/pr-dhl-woocommerce/assets/js/pr-dhl-checkout-frontend.js
@@ -469,8 +469,9 @@ jQuery( document ).ready( function ( $ ) {
 
 					prev_day = value_times.dayOfWeek
 
-					openingTimes += value_times.opens + ' - ' + value_times.closes
-
+					var opens     = value_times.opens.slice( 0, -3 );
+					var closes    = value_times.closes.slice( 0, -3 );
+					openingTimes += opens + ' - ' + closes;
 				} )
 
 				// Get services
@@ -636,7 +637,9 @@ jQuery( document ).ready( function ( $ ) {
 
 					prev_day = value_times.dayOfWeek
 
-					openingTimes += value_times.opens + ' - ' + value_times.closes
+					var opens     = value_times.opens.slice( 0, -3 );
+					var closes    = value_times.closes.slice( 0, -3 );
+					openingTimes += opens + ' - ' + closes;
 				} )
 
 				// Get services


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .
Removed seconds part from open and close time that appear on map marker popup in the shortcode checkout page 

### How to test the changes in this Pull Request:

1. Add a product to your cart.  
2. Go to the checkout page.  
3. On the map, click on a Packstation or branch marker to open the popup with location details.  
4. You’ll see the opening and closing times displayed with hours and minutes only. 

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fix: remove seconds part from open and close time on the map popup