### PR TITLE
Fix missing packagedQuantity when creating labels

### DIFF
--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -240,6 +240,7 @@ class Client extends API_Client {
 				'itemDescription' => $item['itemDescription'],
 				'countryOfOrigin' => $item['countryOfOrigin'],
 				'hsCode'          => $item['hsCode'],
+				'packagedQuantity'  => $item['packagedQuantity'],
 				'itemValue'       => array(
 					'currency' => $item['itemValue']['currency'],
 					'value'    => $item['itemValue']['amount'],

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -237,15 +237,15 @@ class Client extends API_Client {
 		$items = array();
 		foreach ( $request_info->items as $item ) {
 			$items[] = array(
-				'itemDescription' => $item['itemDescription'],
-				'countryOfOrigin' => $item['countryOfOrigin'],
-				'hsCode'          => $item['hsCode'],
-				'packagedQuantity'  => $item['packagedQuantity'],
-				'itemValue'       => array(
+				'itemDescription'  => $item['itemDescription'],
+				'countryOfOrigin'  => $item['countryOfOrigin'],
+				'hsCode'           => $item['hsCode'],
+				'packagedQuantity' => $item['packagedQuantity'],
+				'itemValue'        => array(
 					'currency' => $item['itemValue']['currency'],
 					'value'    => $item['itemValue']['amount'],
 				),
-				'itemWeight'      => array(
+				'itemWeight'       => array(
 					'uom'   => 'kg' === $item['itemWeight']['uom'] ? 'kg' : 'g', // its converted to grams in item_info.
 					'value' => $item['itemWeight']['value'],
 				),

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -75,12 +75,11 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
-= 3.8.3 =
-* Fix: Always send `packagedQuantity` for every customs item to prevent “missing parameter” errors.
-
 = 3.8.2 =
 * Add: OpenStreetMap support to the checkout shipping location finder.
 * Add: New product editor compatibility.
+* Add: Allow customers to choose Drop-off point from a dropdown list.
+* Fix: Always send `packagedQuantity` for every customs item to prevent “missing parameter” errors.
 
 = 3.8.1 =
 * Fix: PHP fatal error related to class loading conflicts in environments with multiple active autoloaders.

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.8.3 =
+* Fix: Always send `packagedQuantity` for every customs item to prevent “missing parameter” errors.
+
 = 3.8.2 =
 * Add: OpenStreetMap support to the checkout shipping location finder.
 * Add: New product editor compatibility.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,13 +75,11 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
-= 3.8.3 =
-* Fix: Always send `packagedQuantity` for every customs item to prevent “missing parameter” errors.
-
 = 3.8.2 =
 * Add: OpenStreetMap support to the checkout shipping location finder.
 * Add: New product editor compatibility.
 * Add: Allow customers to choose Drop-off point from a dropdown list.
+* Fix: Always send `packagedQuantity` for every customs item to prevent “missing parameter” errors.
 
 = 3.8.1 =
 * Fix: PHP fatal error related to class loading conflicts in environments with multiple active autoloaders.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.8.3 =
+* Fix: Always send `packagedQuantity` for every customs item to prevent “missing parameter” errors.
+
 = 3.8.2 =
 * Add: OpenStreetMap support to the checkout shipping location finder.
 * Add: New product editor compatibility.


### PR DESCRIPTION
### All Submissions:

* [x ] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x ] Have you successfully run tests with your changes locally?
* [x ] Have you tested both blocks/non-blocks cart/checkout?
* [ x] Have you tested the cart and checkout as both a logged-in user and a guest?
* [x ] Have you successfully placed an order as both a logged-in user and a guest?
* [ x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. On checkout, enter a non‑German shipping address 
2. Place the order and generate the DHL label
3. Verify that the request includes the international address under `consignee` and that no “missing packagedQuantity” or address errors occur.  

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
