### PR TITLE
Fix Cash on Delivery missing from DHL Paket REST API labels

### DIFF
--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -215,8 +215,8 @@ class Client extends API_Client {
 								'value'    => $request_info->shipment['cod_value'],
 							),
 							'bankAccount'   => $bank_data,
-							'transferNote1' => $request_info->args['dhl_settings']['bank_ref'],
-							'transferNote2' => $request_info->args['dhl_settings']['bank_ref_2'],
+							'transferNote1' => $request_info->args['dhl_settings']['bank_ref'] ?? '',
+							'transferNote2' => $request_info->args['dhl_settings']['bank_ref_2'] ?? '',
 						);
 
 					}

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
@@ -858,6 +858,40 @@ class Item_Info {
 				'default' => '',
 				'rename'  => 'additionalInsurance',
 			),
+			'cod_value'              => array(
+				'default'  => '',
+				'rename'   => 'cashOnDelivery',
+				'validate' => function ( $value ) use ( $self ) {
+					// Only validate when Cash on Delivery is set for this order.
+					if ( empty( $value ) ) {
+						return;
+					}
+
+					$currency = $self->args['order_details']['currency'] ?? '';
+
+					// DHL requires the Cash on Delivery amount to be in Euro.
+					if ( 'EUR' !== $currency ) {
+						throw new Exception(
+							sprintf(
+								/* translators: %s: the order's currency code, e.g. "USD". */
+								esc_html__( 'Cash on Delivery is only available for orders in Euro (EUR). This order uses %s, so a Cash on Delivery label cannot be created.', 'dhl-for-woocommerce' ),
+								esc_html( $currency )
+							)
+						);
+					}
+
+					// DHL requires bank account details to transfer the collected Cash on Delivery amount.
+					$settings    = $self->args['dhl_settings'] ?? array();
+					$bank_holder = $settings['bank_holder'] ?? '';
+					$bank_iban   = $settings['bank_iban'] ?? '';
+
+					if ( empty( $bank_holder ) || empty( $bank_iban ) ) {
+						throw new Exception(
+							esc_html__( 'Cash on Delivery requires your bank account details. Please add the Account Owner and IBAN under the DHL "Bank Details" settings to create a Cash on Delivery label.', 'dhl-for-woocommerce' )
+						);
+					}
+				},
+			),
 			'bulky_goods'            => array(
 				'default' => '',
 				'rename'  => 'bulkyGoods',

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -817,7 +817,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 			$args['order_details']['dimUom'] = get_option( 'woocommerce_dimension_unit' );
 
-			if ( $this->is_cod_payment_method( $order_id ) ) {
+			if ( $this->is_cod_payment_method( $order_id ) && empty( $args['order_details']['cod_value'] ) ) {
 				$args['order_details']['cod_value'] = $order->get_total();
 			}
 

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -71,6 +71,8 @@ More detailed instructions on how to set up your store and configure it are cons
 * Fix: DHL Checkout Blocks text is now translated on the frontend.
 * Fix: Update missing German translations.
 * Fix: WooCommerce Subscriptions compatibility — no longer logs the "wcs_renewal_order_meta_query is deprecated" notice on every subscription renewal.
+* Fix: Cash on Delivery details now appear on DHL Paket labels created via the REST API.
+* Fix: Show a clear error when a Cash on Delivery label can't be created because the order isn't in Euro or bank details are missing.
 
 = 3.9.7 =
 * Fix: Errors appear when trying to save map settings.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -79,6 +79,8 @@ More detailed instructions on how to set up your store and configure it are cons
 * Fix: DHL Checkout Blocks text is now translated on the frontend.
 * Fix: Update missing German translations.
 * Fix: WooCommerce Subscriptions compatibility — no longer logs the "wcs_renewal_order_meta_query is deprecated" notice on every subscription renewal.
+* Fix: Cash on Delivery details now appear on DHL Paket labels created via the REST API.
+* Fix: Show a clear error when a Cash on Delivery label can't be created because the order isn't in Euro or bank details are missing.
 
 = 3.9.7 =
 * Fix: Errors appear when trying to save map settings.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [x] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fix Cash on Delivery information missing from DHL Paket labels when using the REST API.
The plugin was not sending the COD amount to the DHL API, so the COD icon and details never appeared on the generated label. Also fixed a secondary issue where the saved COD amount could be overwritten by the order total when regenerating a label.

Closes # .
https://wordpress.org/support/topic/cash-on-delivery-information-missing-on-label/

### How to test the changes in this Pull Request:

1. Place a test order using Cash on Delivery payment gateway.
2. Go to the order in WP admin and generate a DHL label via the REST API.
3. Confirm the label includes the Cash on Delivery icon and amount.
4. Save a custom COD amount on the order, regenerate the label, and confirm the saved amount is not replaced by the order total.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry
  > Fix: Cash on Delivery amount and icon missing from DHL Paket labels generated via the REST API.
  > Fix: Preserve the saved Cash on Delivery amount when regenerating labels instead of overwriting it with the order total.
