### PR TITLE
Generate JSON translations for checkout blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /pr-dhl-woocommerce/node_modules
 /pr-dhl-woocommerce/.eslintcache
 /pr-dhl-woocommerce/build
+/pr-dhl-woocommerce/lang/*.json
 pr-dhl-woocommerce.zip
 dhl-for-woocommerce.zip

--- a/pr-dhl-woocommerce/composer.json
+++ b/pr-dhl-woocommerce/composer.json
@@ -13,7 +13,7 @@
     "archive": {
         "exclude": [
             "!/assets",
-            "!/languages",
+            "!/lang",
             "/node_modules",
             "bin",
             "tests",

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-blocks-integration.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-blocks-integration.php
@@ -124,7 +124,7 @@ class PR_DHL_Blocks_Integration implements IntegrationInterface {
 		wp_set_script_translations(
 			'pr-dhl-preferred-services-integration',
 			'dhl-for-woocommerce',
-			PR_DHL_PLUGIN_DIR_PATH . '/languages'
+			PR_DHL_PLUGIN_DIR_PATH . '/lang'
 		);
 	}
 
@@ -169,7 +169,7 @@ class PR_DHL_Blocks_Integration implements IntegrationInterface {
 		wp_set_script_translations(
 			$handle,
 			'dhl-for-woocommerce',
-			PR_DHL_PLUGIN_DIR_PATH . '/languages'
+			PR_DHL_PLUGIN_DIR_PATH . '/lang'
 		);
 	}
 
@@ -202,7 +202,7 @@ class PR_DHL_Blocks_Integration implements IntegrationInterface {
 		wp_set_script_translations(
 			$handle,
 			'dhl-for-woocommerce',
-			PR_DHL_PLUGIN_DIR_PATH . '/languages'
+			PR_DHL_PLUGIN_DIR_PATH . '/lang'
 		);
 	}
 

--- a/pr-dhl-woocommerce/package.json
+++ b/pr-dhl-woocommerce/package.json
@@ -16,7 +16,7 @@
 		"env": "wp-env",
 		"makepot": "vendor/bin/wp i18n make-pot ./ lang/$npm_package_name.pot --exclude=node_modules,tests,docs,vendor",
 		"updatepo": "npm run makepot && vendor/bin/wp i18n update-po lang/$npm_package_name.pot lang/",
-		"makejson": "vendor/bin/wp i18n make-json lang/ lang/ --no-purge"
+		"makejson": "vendor/bin/wp i18n make-json lang/ lang/"
 	},
 	"dependencies": {
 		"@wordpress/icons": "^9.49.0",

--- a/pr-dhl-woocommerce/package.json
+++ b/pr-dhl-woocommerce/package.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {
-		"build": "npm run prebuild && composer install && wp-scripts build && npm run makepot && composer install --no-dev && npm run archive",
+		"build": "npm run prebuild && composer install && wp-scripts build && npm run updatepo && npm run makejson && composer install --no-dev && npm run archive",
 		"archive": "composer archive --file=dhl-for-woocommerce --format=zip",
 		"prebuild": "rm -rf $npm_package_name && rm -f $npm_package_name.zip",
 		"format": "wp-scripts format",
@@ -14,7 +14,9 @@
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start",
 		"env": "wp-env",
-		"makepot": "vendor/bin/wp i18n make-pot ./ lang/$npm_package_name.pot --exclude=node_modules,tests,docs,vendor"
+		"makepot": "vendor/bin/wp i18n make-pot ./ lang/$npm_package_name.pot --exclude=node_modules,tests,docs,vendor",
+		"updatepo": "npm run makepot && vendor/bin/wp i18n update-po lang/$npm_package_name.pot lang/",
+		"makejson": "vendor/bin/wp i18n make-json lang/ lang/ --no-purge"
 	},
 	"dependencies": {
 		"@wordpress/icons": "^9.49.0",

--- a/pr-dhl-woocommerce/package.json
+++ b/pr-dhl-woocommerce/package.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {
-		"build": "npm run prebuild && composer install && wp-scripts build && npm run updatepo && npm run makejson && composer install --no-dev && npm run archive",
+		"build": "npm run prebuild && composer install && wp-scripts build && npm run updatepo && npm run makejson && npm run makemo && composer install --no-dev && npm run archive",
 		"archive": "composer archive --file=dhl-for-woocommerce --format=zip",
 		"prebuild": "rm -rf $npm_package_name && rm -f $npm_package_name.zip",
 		"format": "wp-scripts format",
@@ -16,7 +16,8 @@
 		"env": "wp-env",
 		"makepot": "vendor/bin/wp i18n make-pot ./ lang/$npm_package_name.pot --exclude=node_modules,tests,docs,vendor",
 		"updatepo": "npm run makepot && vendor/bin/wp i18n update-po lang/$npm_package_name.pot lang/",
-		"makejson": "vendor/bin/wp i18n make-json lang/ lang/"
+		"makejson": "vendor/bin/wp i18n make-json lang/ lang/",
+		"makemo": "vendor/bin/wp i18n make-mo lang/ lang/"
 	},
 	"dependencies": {
 		"@wordpress/icons": "^9.49.0",

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -67,6 +67,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.9.8 =
+* Fix: DHL Checkout Blocks text is now translated on the frontend.
+
 = 3.9.7 =
 * Fix: Errors appear when trying to save map settings.
 * Fix: Delivery options now correctly appear when shipping to Germany, even if the billing country is different.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 3.9.8 =
+* Fix: DHL Checkout Blocks text is now translated on the frontend.
+
 = 3.9.7 =
 * Fix: Errors appear when trying to save map settings.
 * Fix: Delivery options now correctly appear when shipping to Germany, even if the billing country is different.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

### Changes proposed in this Pull Request:

Checkout block strings (the `__()` calls in the DHL Preferred Services, Closest Drop Point, and Parcel Finder blocks) were never translated on the front end because the plugin never generated the per-script translation JSON files that `wp_set_script_translations()` needs. This PR adds that generation step — mirroring the approach already used in the PostNL plugin — and fixes a related path bug.

- **`package.json`** — added `updatepo` and `makejson` scripts and wired them into `build`. The build now runs `wp-scripts build` first, then `make-pot` / `update-po`, then `make-json`, so the generated JSON filenames are hashed from the compiled `build/*.js` paths that WordPress actually looks up at runtime.
- **`includes/class-pr-dhl-blocks-integration.php`** — the three `wp_set_script_translations()` calls pointed at a non-existent `/languages` directory; corrected to `/lang`, which matches the plugin's `Domain Path`, `load_plugin_textdomain()`, and the existing `.pot` / `.po` / `.mo` files.
- **`composer.json`** — the archive config now force-includes `/lang` (it previously referenced a stale `/languages`) so the generated JSON ships in the release zip.
- **`.gitignore`** — the generated `lang/*.json` are treated like the `build/` output: produced at build time and shipped in the release zip, but not committed (they are regenerated on every build).

### How to test the changes in this Pull Request:

1. Check out this branch and install dependencies: `composer install` and `npm install`.
2. Build the plugin and generate translations: `npm run build` (or, to run only the i18n step after a build, `npm run updatepo && npm run makejson`).
3. Confirm JSON files are generated in `lang/`, e.g. `lang/dhl-for-woocommerce-de_DE-<hash>.json`.
4. Confirm the hash matches what WordPress looks up: `php -r "echo md5('build/index.js');"` should equal the `<hash>` of one of the generated `dhl-for-woocommerce-de_DE-<hash>.json` files.
5. On a WooCommerce store using the **Checkout block**, set the site language to German: *Settings → General → Site Language → Deutsch*, then save.
6. Open the block-based Checkout on the front end with the DHL Preferred Delivery / Parcel Finder options enabled and confirm DHL block strings render in German (e.g. “DHL Preferred Delivery…” → “DHL Wunschzustellung…”, “Drop-off location or neighbor” → “Ablageort oder Nachbar”). Previously these stayed in English.
7. Switch the site language back to English and confirm the strings revert.

> Note: because the JSON files are generated (not committed), a fresh checkout must run the build step above before the translations appear — the same as the existing `build/` output.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Generate JSON translation files for the checkout blocks so block strings can be translated on the front end, and fix the block script translations directory path.
