### PR TITLE
Fix checkout block JS translation file generation

### DIFF
--- a/pr-dhl-woocommerce/.npmrc
+++ b/pr-dhl-woocommerce/.npmrc
@@ -1,0 +1,5 @@
+# Run npm scripts through bash on every platform.
+# On Windows, npm otherwise defaults to cmd.exe even when launched from Git Bash,
+# which breaks POSIX-style scripts (forward-slash bin paths, $npm_package_name, rm -rf).
+# Mac/Linux already use a POSIX shell, so this is a no-op for them.
+script-shell = bash

--- a/pr-dhl-woocommerce/composer.json
+++ b/pr-dhl-woocommerce/composer.json
@@ -13,8 +13,9 @@
     "archive": {
         "exclude": [
             "!/assets",
-            "!/languages",
+            "!/lang",
             "/node_modules",
+            "i18n-map.json",
             "bin",
             "tests",
             "LICENSE",

--- a/pr-dhl-woocommerce/i18n-map.json
+++ b/pr-dhl-woocommerce/i18n-map.json
@@ -1,0 +1,15 @@
+{
+	"includes/checkout-blocks/index.js": ["build/index.js"],
+	"includes/checkout-blocks/dhl-preferred-services/index.js": ["build/index.js", "build/pr-dhl-preferred-services.js"],
+	"includes/checkout-blocks/dhl-preferred-services/edit.js": ["build/index.js", "build/pr-dhl-preferred-services.js"],
+	"includes/checkout-blocks/dhl-preferred-services/block.js": ["build/pr-dhl-preferred-services-frontend.js"],
+	"includes/checkout-blocks/dhl-preferred-services/frontend.js": ["build/pr-dhl-preferred-services-frontend.js"],
+	"includes/checkout-blocks/dhl-parcel-finder/index.js": ["build/index.js", "build/pr-dhl-parcel-finder.js"],
+	"includes/checkout-blocks/dhl-parcel-finder/edit.js": ["build/index.js", "build/pr-dhl-parcel-finder.js"],
+	"includes/checkout-blocks/dhl-parcel-finder/block.js": ["build/pr-dhl-parcel-finder-frontend.js"],
+	"includes/checkout-blocks/dhl-parcel-finder/frontend.js": ["build/pr-dhl-parcel-finder-frontend.js"],
+	"includes/checkout-blocks/dhl-closest-drop-point/index.js": ["build/index.js", "build/pr-dhl-closest-drop-point.js"],
+	"includes/checkout-blocks/dhl-closest-drop-point/edit.js": ["build/index.js", "build/pr-dhl-closest-drop-point.js"],
+	"includes/checkout-blocks/dhl-closest-drop-point/block.js": ["build/pr-dhl-closest-drop-point-frontend.js"],
+	"includes/checkout-blocks/dhl-closest-drop-point/frontend.js": ["build/pr-dhl-closest-drop-point-frontend.js"]
+}

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-blocks-integration.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-blocks-integration.php
@@ -124,7 +124,7 @@ class PR_DHL_Blocks_Integration implements IntegrationInterface {
 		wp_set_script_translations(
 			'pr-dhl-preferred-services-integration',
 			'dhl-for-woocommerce',
-			PR_DHL_PLUGIN_DIR_PATH . '/languages'
+			PR_DHL_PLUGIN_DIR_PATH . '/lang'
 		);
 	}
 
@@ -169,7 +169,7 @@ class PR_DHL_Blocks_Integration implements IntegrationInterface {
 		wp_set_script_translations(
 			$handle,
 			'dhl-for-woocommerce',
-			PR_DHL_PLUGIN_DIR_PATH . '/languages'
+			PR_DHL_PLUGIN_DIR_PATH . '/lang'
 		);
 	}
 
@@ -202,7 +202,7 @@ class PR_DHL_Blocks_Integration implements IntegrationInterface {
 		wp_set_script_translations(
 			$handle,
 			'dhl-for-woocommerce',
-			PR_DHL_PLUGIN_DIR_PATH . '/languages'
+			PR_DHL_PLUGIN_DIR_PATH . '/lang'
 		);
 	}
 

--- a/pr-dhl-woocommerce/package.json
+++ b/pr-dhl-woocommerce/package.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {
-		"build": "npm run prebuild && composer install && wp-scripts build && npm run makepot && composer install --no-dev && npm run archive",
+		"build": "npm run prebuild && composer install && wp-scripts build && npm run makepot && npm run makejson && composer install --no-dev && npm run archive",
 		"archive": "composer archive --file=dhl-for-woocommerce --format=zip",
 		"prebuild": "rm -rf $npm_package_name && rm -f $npm_package_name.zip",
 		"format": "wp-scripts format",
@@ -14,7 +14,8 @@
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start",
 		"env": "wp-env",
-		"makepot": "vendor/bin/wp i18n make-pot ./ lang/$npm_package_name.pot --exclude=node_modules,tests,docs,vendor"
+		"makepot": "vendor/bin/wp i18n make-pot ./ lang/$npm_package_name.pot --exclude=node_modules,tests,docs,vendor",
+		"makejson": "vendor/bin/wp i18n make-json lang --no-purge --pretty-print --use-map=i18n-map.json"
 	},
 	"dependencies": {
 		"@wordpress/icons": "^9.49.0",


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?



<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes checkout block JS translations 

npm run build was only generating the .pot file and never the JSON files WooCommerce blocks need at runtime. 

This adds a make-json build step (+ an i18n-map.json so filenames match the enqueued bundles), loads translations from /lang, and adds an .npmrc so the build runs on Windows. 

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
