### PR TITLE
Require order-management capability to download Deutsche Post waybill labels

### DIFF
--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
@@ -1146,6 +1146,11 @@ class PR_DHL_WC_Order_Deutsche_Post extends PR_DHL_WC_Order {
 			return;
 		}
 
+		// Only users who can manage shop orders may download the waybill, matching the sibling label endpoint.
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			return;
+		}
+
 		$dhl_obj    = PR_DHL()->get_dhl_factory();
 		$label_path = $dhl_obj->get_dhl_order_label_file_info( $dhl_order_id )->path;
 

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -67,6 +67,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.0.1 =
+* Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
+
 = 4.0.0 =
 * Drop SOAP API support.
 * Add: Deutsche Post Internetmarke — buy and print postage stamps for letters directly from a WooCommerce order.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.0.1 =
+* Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
+
 = 4.0.0 =
 * Drop SOAP API support.
 * Add: Deutsche Post Internetmarke — buy and print postage stamps for letters directly from a WooCommerce order.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

_Cart/checkout and order-placement items are N/A: this changes an admin-side label download endpoint only, with no cart, checkout, or order-placement surface._

### Changes proposed in this Pull Request:

Adds an `edit_shop_orders` capability check to the Deutsche Post AWB (waybill) download endpoint (`/dhl_download_awb_label/{id}/`) in `process_download_awb_label()` before the stored PDF is served.

Previously this endpoint streamed the waybill file without a capability check, unlike the sibling label download endpoint `process_download_label()` (`abstract-pr-dhl-wc-order.php`) and the Internetmarke handlers, which already require `edit_shop_orders`. This aligns the waybill endpoint with the plugin's existing authorization pattern so shipping documents are only served to users who can manage orders.

The check is placed after the existing endpoint-parameter bail so unrelated front-end queries still return early, and before the file path is resolved or streamed.

https://app.clickup.com/t/868kcx1n9

### How to test the changes in this Pull Request:

1. On a store with Deutsche Post configured (non-German store base) and an order that has a generated AWB label, note the DHL order ID used by the download link.
2. While **logged out** (or as a user without `edit_shop_orders`), request `/dhl_download_awb_label/{id}/` — expected: the PDF is **not** served (front-end/404 response), whereas before the fix the file was returned.
3. While **logged in as a shop manager/admin**, trigger the AWB download from the order screen — expected: the waybill PDF downloads exactly as before.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
