### PR TITLE
Store DHL label files in an unguessable protected subfolder to prevent direct download

### DIFF
--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -434,13 +434,9 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				return '';
 			}
 
-			// If no 'label_path' isset but a 'label_url' is set them return it...
-			// ... this indicates an old download style label!
-			if ( ! isset( $label_tracking_info['label_path'] ) && isset( $label_tracking_info['label_url'] ) ) {
-				return $label_tracking_info['label_url'];
-			}
-
-			// Override URL with our solution's download label endpoint:
+			// Always serve through our download endpoint so the file is streamed from the
+			// protected folder after a capability check, including old "download style"
+			// labels that only stored a public 'label_url'.
 			return $this->generate_download_url( '/' . self::DHL_DOWNLOAD_ENDPOINT . '/' . $order_id );
 		}
 
@@ -1277,7 +1273,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						}
 
 						if ( ! empty( $label_tracking_info['label_path'] ) ) {
-							array_push( $merge_files, $label_tracking_info['label_path'] );
+							array_push( $merge_files, PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] ) );
 						}
 					} catch ( Exception $e ) {
 						$array_messages[] = array(
@@ -1563,8 +1559,13 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				$label_type = isset( $_GET['dhl_label_type'] ) ? sanitize_key( wp_unslash( $_GET['dhl_label_type'] ) ) : '';
 				if ( 'return' === $label_type && ! empty( $label_tracking_info['return_label_path'] ) ) {
 					$label_path = $label_tracking_info['return_label_path'];
-				} else {
+				} elseif ( ! empty( $label_tracking_info['label_path'] ) ) {
 					$label_path = $label_tracking_info['label_path'];
+				} elseif ( ! empty( $label_tracking_info['label_url'] ) ) {
+					// Old "download style" labels stored only a public URL; resolve by file name.
+					$label_path = PR_DHL()->get_dhl_label_folder_dir() . basename( $label_tracking_info['label_url'] );
+				} else {
+					$label_path = '';
 				}
 
 				if ( false == $this->download_label( $label_path ) ) {
@@ -1617,6 +1618,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 	   * @return boolean|void
 	   */
 	  protected function download_label( $file_path ) {
+		  $file_path = PR_DHL()->resolve_label_file_path( $file_path );
+
 		  if ( ! empty( $file_path ) && is_string( $file_path ) && file_exists( $file_path ) ) {
 			  // Check if buffer exists, then flush any buffered output to prevent it from being included in the file's content
 			  if ( ob_get_contents() ) {

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-internetmarke.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-internetmarke.php
@@ -889,8 +889,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Internetmarke' ) ) :
 		 * @return string
 		 */
 		protected function get_label_file_path( $order_id ) {
-			$upload_dir = wp_upload_dir();
-			return $upload_dir['basedir'] . '/woocommerce_dhl_label/dhl-im-label-' . (int) $order_id . '.pdf';
+			return PR_DHL()->get_dhl_label_folder_dir() . 'dhl-im-label-' . (int) $order_id . '.pdf';
 		}
 
 		/**

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-internetmarke.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-internetmarke.php
@@ -889,7 +889,9 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Internetmarke' ) ) :
 		 * @return string
 		 */
 		protected function get_label_file_path( $order_id ) {
-			return PR_DHL()->get_dhl_label_folder_dir() . 'dhl-im-label-' . (int) $order_id . '.pdf';
+			$dir = PR_DHL()->get_dhl_label_folder_dir();
+
+			return '' === $dir ? '' : $dir . 'dhl-im-label-' . (int) $order_id . '.pdf';
 		}
 
 		/**

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
@@ -1101,8 +1101,12 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Paket' ) ) :
 				return $attachments;
 			}
 
-			if ( ! empty( $label_tracking_info['return_label_path'] ) && file_exists( $label_tracking_info['return_label_path'] ) ) {
-				$attachments[] = $label_tracking_info['return_label_path'];
+			$return_label_path = ! empty( $label_tracking_info['return_label_path'] )
+				? PR_DHL()->resolve_label_file_path( $label_tracking_info['return_label_path'] )
+				: '';
+
+			if ( '' !== $return_label_path && file_exists( $return_label_path ) ) {
+				$attachments[] = $return_label_path;
 			} else {
 				// The order has a DHL label and emailing the return label is enabled, but no separate
 				// return label file is available to attach: either "Separate Return Label" was off when

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-deutsche-post.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-deutsche-post.php
@@ -365,7 +365,7 @@ class PR_DHL_API_Deutsche_Post extends PR_DHL_API {
 			throw new Exception( esc_html__( 'DHL Label has no path!', 'dhl-for-woocommerce' ) );
 		}
 
-		$label_path = $label_info['label_path'];
+		$label_path = PR_DHL()->resolve_label_file_path( $label_info['label_path'] );
 
 		if ( file_exists( $label_path ) ) {
 			$res = wp_delete_file( $label_path );

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-label.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-label.php
@@ -51,6 +51,7 @@ class PR_DHL_API_REST_Label extends PR_DHL_API_REST implements PR_DHL_API_Label 
 	public function delete_dhl_label( $args ) {
 		$upload_path = wp_upload_dir();
 		$label_path  = str_replace( $upload_path['url'], $upload_path['path'], $args['label_url'] );
+		$label_path  = PR_DHL()->resolve_label_file_path( $label_path );
 
 		if ( file_exists( $label_path ) ) {
 			if ( ! is_writable( $label_path ) ) {

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-parcel-de.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-parcel-de.php
@@ -120,11 +120,14 @@ class PR_DHL_API_REST_Parcel_DE extends PR_DHL_API_REST_Paket {
 			throw new Exception( esc_html__( 'DHL Label has no path!', 'dhl-for-woocommerce' ) );
 		}
 
-		$label_path = $label_info['label_path'];
+		$label_path = PR_DHL()->resolve_label_file_path( $label_info['label_path'] );
 
 		// Remove the separate return label file too, if one was saved.
-		if ( ! empty( $label_info['return_label_path'] ) && file_exists( $label_info['return_label_path'] ) ) {
-			wp_delete_file( $label_info['return_label_path'] );
+		if ( ! empty( $label_info['return_label_path'] ) ) {
+			$return_label_path = PR_DHL()->resolve_label_file_path( $label_info['return_label_path'] );
+			if ( file_exists( $return_label_path ) ) {
+				wp_delete_file( $return_label_path );
+			}
 		}
 
 		if ( file_exists( $label_path ) ) {

--- a/pr-dhl-woocommerce/pr-dhl-woocommerce.php
+++ b/pr-dhl-woocommerce/pr-dhl-woocommerce.php
@@ -982,22 +982,34 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 		/**
 		 * Installation functions
 		 *
-		 * Create temporary folder and files. DHL labels will be stored here as required
-		 *
-		 * empty_pdf_task will delete them hourly
+		 * Create the folder where DHL labels are stored. Labels are kept in an unguessable,
+		 * per-site subfolder and further protected with an Apache `.htaccess` deny rule, so
+		 * they cannot be reached directly on web servers that ignore `.htaccess` (e.g. Nginx).
 		 */
 		public function create_dhl_label_folder() {
 			// Install files and folders for uploading files and prevent hotlinking
 			$upload_dir = wp_upload_dir();
+			$base       = $upload_dir['basedir'] . '/woocommerce_dhl_label';
+			$secret     = $base . '/' . $this->get_dhl_label_folder_key();
 
 			$files = array(
 				array(
-					'base'    => $upload_dir['basedir'] . '/woocommerce_dhl_label',
+					'base'    => $base,
 					'file'    => '.htaccess',
 					'content' => 'deny from all',
 				),
 				array(
-					'base'    => $upload_dir['basedir'] . '/woocommerce_dhl_label',
+					'base'    => $base,
+					'file'    => 'index.html',
+					'content' => '',
+				),
+				array(
+					'base'    => $secret,
+					'file'    => '.htaccess',
+					'content' => 'deny from all',
+				),
+				array(
+					'base'    => $secret,
 					'file'    => 'index.html',
 					'content' => '',
 				),
@@ -1013,17 +1025,107 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 			}
 		}
 
+		/**
+		 * Returns the unguessable, per-site subfolder name used to store DHL labels.
+		 *
+		 * Generated once and stored in the options table so label URLs cannot be enumerated
+		 * from predictable order IDs.
+		 *
+		 * @return string
+		 */
+		private function get_dhl_label_folder_key() {
+			$key = get_option( 'pr_dhl_label_folder_key' );
+
+			if ( ! is_string( $key ) || '' === $key ) {
+				$key = wp_generate_password( 20, false );
+				update_option( 'pr_dhl_label_folder_key', $key, false );
+			}
+
+			return $key;
+		}
+
 		public function dhl_label_folder_check() {
 			$upload_dir = wp_upload_dir();
-			if ( ! file_exists( $upload_dir['basedir'] . '/woocommerce_dhl_label/.htaccess' ) ) {
+			$base       = $upload_dir['basedir'] . '/woocommerce_dhl_label';
+			$secret     = $base . '/' . $this->get_dhl_label_folder_key();
+
+			if ( ! file_exists( $base . '/.htaccess' ) || ! file_exists( $secret . '/.htaccess' ) ) {
 				$this->create_dhl_label_folder();
+			}
+
+			$this->maybe_migrate_dhl_labels();
+		}
+
+		/**
+		 * Moves any previously stored label files out of the public folder root into the
+		 * unguessable subfolder, so labels generated before this protection was added are no
+		 * longer reachable at a predictable uploads URL. Runs once per site.
+		 *
+		 * @return void
+		 */
+		private function maybe_migrate_dhl_labels() {
+			if ( get_option( 'pr_dhl_label_folder_migrated' ) ) {
+				return;
+			}
+
+			$upload_dir = wp_upload_dir();
+			$root       = trailingslashit( $upload_dir['basedir'] . '/woocommerce_dhl_label' );
+			$secret     = $this->get_dhl_label_folder_dir();
+
+			// Only migrate once the protected subfolder actually exists, so a file is never
+			// left behind at the public path while the one-shot flag is already set.
+			if ( '' === $secret || ! is_dir( $secret ) || ! is_dir( $root ) ) {
+				return;
+			}
+
+			$entries  = @scandir( $root );
+			$migrated = is_array( $entries );
+
+			if ( is_array( $entries ) ) {
+				foreach ( $entries as $entry ) {
+					if ( in_array( $entry, array( '.', '..', '.htaccess', 'index.html' ), true ) ) {
+						continue;
+					}
+
+					$source = $root . $entry;
+
+					// Only move label files; leave the protected subfolder itself in place.
+					if ( ! is_file( $source ) ) {
+						continue;
+					}
+
+					$destination = $secret . $entry;
+
+					// A protected copy already exists: drop the now-redundant public copy so it
+					// is not left exposed at the predictable path.
+					if ( file_exists( $destination ) ) {
+						wp_delete_file( $source );
+
+						if ( file_exists( $source ) ) {
+							$migrated = false;
+						}
+
+						continue;
+					}
+
+					if ( ! @rename( $source, $destination ) ) {
+						$migrated = false;
+					}
+				}
+			}
+
+			// Only mark migration complete when every file moved, so a transient failure
+			// retries on a later request instead of leaving labels exposed at the public path.
+			if ( $migrated ) {
+				update_option( 'pr_dhl_label_folder_migrated', 1 );
 			}
 		}
 
 		public function get_dhl_label_folder_dir() {
 			$upload_dir = wp_upload_dir();
-			if ( file_exists( $upload_dir['basedir'] . '/woocommerce_dhl_label/.htaccess' ) ) {
-				return $upload_dir['basedir'] . '/woocommerce_dhl_label/';
+			$secret     = '/woocommerce_dhl_label/' . $this->get_dhl_label_folder_key();
+			if ( file_exists( $upload_dir['basedir'] . $secret . '/.htaccess' ) ) {
+				return $upload_dir['basedir'] . $secret . '/';
 			}
 
 			return '';
@@ -1031,11 +1133,39 @@ if ( ! class_exists( 'PR_DHL_WC' ) ) :
 
 		public function get_dhl_label_folder_url() {
 			$upload_dir = wp_upload_dir();
-			if ( file_exists( $upload_dir['basedir'] . '/woocommerce_dhl_label/.htaccess' ) ) {
-				return $upload_dir['baseurl'] . '/woocommerce_dhl_label/';
+			$secret     = '/woocommerce_dhl_label/' . $this->get_dhl_label_folder_key();
+			if ( file_exists( $upload_dir['basedir'] . $secret . '/.htaccess' ) ) {
+				return $upload_dir['baseurl'] . $secret . '/';
 			}
 
 			return '';
+		}
+
+		/**
+		 * Resolves a stored label file path, falling back to the same file name inside the
+		 * current (protected) label folder when the stored path no longer exists, for example
+		 * after previously stored labels were migrated into the protected subfolder.
+		 *
+		 * Only the base file name is used for the fallback, so it cannot escape the label folder.
+		 *
+		 * @param string $file_path
+		 *
+		 * @return string
+		 */
+		public function resolve_label_file_path( $file_path ) {
+			if ( empty( $file_path ) || ! is_string( $file_path ) || file_exists( $file_path ) ) {
+				return $file_path;
+			}
+
+			$dir = $this->get_dhl_label_folder_dir();
+
+			if ( '' === $dir ) {
+				return $file_path;
+			}
+
+			$fallback = $dir . basename( $file_path );
+
+			return ( $fallback !== $file_path && file_exists( $fallback ) ) ? $fallback : $file_path;
 		}
 
 		public function set_account_details( $account_details, $dhl_obj ) {

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -67,6 +67,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.0.1 =
+* Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
+
 = 4.0.0 =
 * Drop SOAP API support.
 * Add: Deutsche Post Internetmarke — buy and print postage stamps for letters directly from a WooCommerce order.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.0.1 =
+* Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
+
 = 4.0.0 =
 * Drop SOAP API support.
 * Add: Deutsche Post Internetmarke — buy and print postage stamps for letters directly from a WooCommerce order.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

_Cart/checkout and order-placement items are N/A: this changes where label PDFs are stored and how they are served on the admin/order side; there is no cart, checkout, or order-placement surface. Automated tests were not run — the plugin has no PHPUnit suite; changes were verified with `php -l` and code review._

### Changes proposed in this Pull Request:

Label PDFs (Paket, Deutsche Post, Internetmarke) were stored under the public uploads folder `uploads/woocommerce_dhl_label/`, protected only by an Apache `.htaccess` deny rule. Web servers that ignore `.htaccess` (e.g. Nginx) served those files directly, and the file names were built from predictable order IDs, so they could be enumerated.

This PR stores labels in an unguessable, per-site subfolder (`woocommerce_dhl_label/{random-key}/`) so the files cannot be reached or enumerated even where `.htaccess` is ignored, while keeping the `.htaccess` deny as Apache defense-in-depth. Downloads continue to be served through the existing capability-checked endpoints.

Specifics:
- Add a per-site secret folder key (stored in the `pr_dhl_label_folder_key` option) and route all label storage/serving through the existing folder helpers.
- Create the secret subfolder with its own `.htaccess` (`deny from all`) + `index.html`.
- One-time migration (`maybe_migrate_dhl_labels`) moves already-stored label files into the secret subfolder so previously generated PDFs are no longer reachable at a predictable URL. It only marks itself complete once every file has moved.
- Add a traversal-safe `resolve_label_file_path()` (uses `basename()`), so labels created before the change (whose absolute path is stored in order meta) still resolve for download, bulk-merge, email attachment, and deletion after migration.
- Route Internetmarke's file path and old "download style" labels through the same helpers/endpoint (the latter now goes through the capability check instead of a raw public URL).

https://app.clickup.com/t/868kcx1q0

### How to test the changes in this Pull Request:

1. On a store with DHL configured, create a label (Paket, Deutsche Post, and/or Internetmarke) so a PDF is generated. Confirm the file now lives under `wp-content/uploads/woocommerce_dhl_label/<random>/` (not directly in `woocommerce_dhl_label/`).
2. Confirm the raw file URL `…/uploads/woocommerce_dhl_label/<original-name>.pdf` is no longer reachable, on both Apache and Nginx.
3. As a Shop Manager/admin, download the label from the order — it downloads as before (served via the capability-checked endpoint).
4. Delete the label from the order — no error, file removed.
5. Upgrade path: with a label file already present in the old `woocommerce_dhl_label/` root before this change, load an order screen once (triggers migration), then confirm the file moved into the `<random>` subfolder and that download/delete of that pre-existing label still work.
6. Bulk label download and (if enabled) the return-label email attachment still include the correct PDFs.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Fix: Store DHL shipping labels in a protected, unguessable location so they cannot be downloaded directly, including on servers that do not honour `.htaccess`.
