### PR TITLE
Cap Parcel DE consignee street at 50 chars and route overflow to additional address

### DIFF
--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
@@ -571,8 +571,11 @@ class Item_Info {
 				},
 			),
 			'address_additional' => array(
-				'rename'  => 'additionalAddressInformation1',
-				'default' => '',
+				'rename'   => 'additionalAddressInformation1',
+				'default'  => '',
+				'sanitize' => function ( $value ) use ( $self ) {
+					return $self->string_length_sanitization( $value, 60 );
+				},
 			),
 			'postcode'           => array(
 				'rename' => 'postalCode',

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
@@ -1325,13 +1325,15 @@ class Item_Info {
 
 		if ( ! empty( $this->args['shipping_address']['address_2'] ) ) {
 
-			// If address_2 greated than 10 chars, try to pass with additional address (does not show for DE)
-			if ( strlen( $this->args['shipping_address']['address_2'] ) > 10 ) {
-				$this->args['shipping_address']['address_additional'] = $this->args['shipping_address']['address_2'];
-				$this->args['shipping_address']['address_2']          = '';
+			// A house number never exceeds 10 chars, so a shorter address_2 is used as-is.
+			if ( strlen( $this->args['shipping_address']['address_2'] ) <= 10 ) {
+				return;
 			}
 
-			return;
+			// Too long to be a house number: keep it as additional info (does not show for DE)
+			// and fall through to recover the real house number from address_1 below.
+			$this->args['shipping_address']['address_additional'] = $this->args['shipping_address']['address_2'];
+			$this->args['shipping_address']['address_2']          = '';
 		}
 
 		$set_key = false;

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Item_Info.php
@@ -144,6 +144,7 @@ class Item_Info {
 		$this->pos_po = PR_DHL()->is_post_office( $args['shipping_address']['address_1'] );
 
 		$this->set_address_2();
+		$this->split_address_street();
 		$this->parse_args();
 	}
 
@@ -557,8 +558,11 @@ class Item_Info {
 				'rename' => 'name2',
 			),
 			'address_1'          => array(
-				'rename' => 'addressStreet',
-				'error'  => esc_html__( 'Shipping "Address 1" is empty!', 'dhl-for-woocommerce' ),
+				'rename'   => 'addressStreet',
+				'error'    => esc_html__( 'Shipping "Address 1" is empty!', 'dhl-for-woocommerce' ),
+				'sanitize' => function ( $value ) use ( $self ) {
+					return $self->string_length_sanitization( $value, 50 );
+				},
 			),
 			'address_2'          => array(
 				'rename'   => 'addressHouse',
@@ -1373,5 +1377,55 @@ class Item_Info {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Keep the consignee street within DHL Parcel DE's 50 character limit.
+	 *
+	 * DHL rejects the whole shipment with a 400 when addressStreet exceeds 50
+	 * characters, so split the street at the last word boundary that still fits
+	 * and move the overflow into the additional-address field (max 60) instead of
+	 * failing. The house number lives in address_2 by now, so it is left alone;
+	 * overflow is prepended to whatever set_address_2() already relocated into the
+	 * additional-address field.
+	 *
+	 * @return void.
+	 */
+	protected function split_address_street() {
+		if ( $this->pos_ps || $this->pos_rs || $this->pos_po ) {
+			return;
+		}
+
+		$max     = 50;
+		$address = $this->args['shipping_address']['address_1'] ?? '';
+
+		if ( strlen( $address ) <= $max ) {
+			return;
+		}
+
+		// Prefer the last space within the limit; fall back to a hard cut when a
+		// single token is already longer than the limit.
+		$boundary = strrpos( substr( $address, 0, $max + 1 ), ' ' );
+
+		if ( false !== $boundary && $boundary > 0 ) {
+			$street   = substr( $address, 0, $boundary );
+			$overflow = substr( $address, $boundary + 1 );
+		} else {
+			$street   = substr( $address, 0, $max );
+			$overflow = substr( $address, $max );
+		}
+
+		$this->args['shipping_address']['address_1'] = trim( $street );
+
+		$overflow = trim( $overflow );
+
+		if ( '' === $overflow ) {
+			return;
+		}
+
+		$additional = $this->args['shipping_address']['address_additional'] ?? '';
+		$additional = '' === $additional ? $overflow : $overflow . ' ' . $additional;
+
+		$this->args['shipping_address']['address_additional'] = $this->string_length_sanitization( $additional, 60 );
 	}
 }

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -70,6 +70,7 @@ More detailed instructions on how to set up your store and configure it are cons
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
+* Fix: Create labels for orders whose street address is longer than 50 characters instead of failing; the extra text now moves to the additional address line.
 
 = 4.0.0 =
 * Drop SOAP API support.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -78,6 +78,7 @@ More detailed instructions on how to set up your store and configure it are cons
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
+* Fix: Create labels for orders whose street address is longer than 50 characters instead of failing; the extra text now moves to the additional address line.
 
 = 4.0.0 =
 * Drop SOAP API support.

--- a/pr-dhl-woocommerce/tests/test-parcel-de-address.php
+++ b/pr-dhl-woocommerce/tests/test-parcel-de-address.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Standalone tests for Parcel DE consignee address handling.
+ *
+ * Exercises Item_Info::set_address_2() and Item_Info::split_address_street() in
+ * isolation, without a WordPress bootstrap: the class is instantiated without its
+ * constructor and the protected methods are invoked via reflection.
+ *
+ * Run: php tests/test-parcel-de-address.php
+ */
+
+namespace {
+	if ( ! function_exists( 'esc_html__' ) ) {
+		function esc_html__( $text, $domain = null ) {
+			return $text;
+		}
+	}
+}
+
+namespace {
+	use PR\DHL\REST_API\Parcel_DE\Item_Info;
+
+	require __DIR__ . '/../includes/REST_API/Parcel_DE/Item_Info.php';
+
+	/**
+	 * Run set_address_2() then split_address_street() over a shipping address.
+	 *
+	 * @param array $shipping The shipping_address args.
+	 * @return array The resulting shipping_address after both methods run.
+	 */
+	function pr_dhl_run_address( array $shipping ) {
+		$ref  = new \ReflectionClass( Item_Info::class );
+		$item = $ref->newInstanceWithoutConstructor();
+
+		// Both methods early-return for Packstation / Parcelshop / Post Office addresses.
+		foreach ( array( 'pos_ps', 'pos_rs', 'pos_po' ) as $flag ) {
+			$prop = $ref->getProperty( $flag );
+			$prop->setAccessible( true );
+			$prop->setValue( $item, false );
+		}
+
+		$item->args = array( 'shipping_address' => $shipping );
+
+		foreach ( array( 'set_address_2', 'split_address_street' ) as $name ) {
+			$method = $ref->getMethod( $name );
+			$method->setAccessible( true );
+			$method->invoke( $item );
+		}
+
+		return $item->args['shipping_address'];
+	}
+
+	$failures = 0;
+
+	/**
+	 * Assert equality and report the outcome.
+	 *
+	 * @param string $label Human readable test name.
+	 * @param mixed  $got   Actual value.
+	 * @param mixed  $want  Expected value.
+	 */
+	function pr_dhl_assert( $label, $got, $want ) {
+		global $failures;
+
+		if ( $got === $want ) {
+			printf( "[PASS] %s\n", $label );
+			return;
+		}
+
+		++$failures;
+		printf( "[FAIL] %s\n       got=%s\n       want=%s\n", $label, var_export( $got, true ), var_export( $want, true ) );
+	}
+
+	$long = 'An der langen Muhlenstrasse neben dem alten Wasserturm 12';
+
+	// Long address_1, empty address_2: the house number is extracted into addressHouse.
+	$r = pr_dhl_run_address( array( 'address_1' => $long, 'address_2' => '', 'country' => 'DE' ) );
+	pr_dhl_assert( 'Long street, empty address_2 -> addressHouse extracted', $r['address_2'], '12' );
+
+	// Long address_1 AND long address_2: address_2 is too long to be a house number, so it
+	// moves to the additional field and the real house number is still recovered from
+	// address_1 (regression fixed - previously addressHouse came back empty -> DHL 400).
+	$r = pr_dhl_run_address( array( 'address_1' => $long, 'address_2' => $long, 'country' => 'DE' ) );
+	pr_dhl_assert( 'Long street and long address_2 -> addressHouse recovered', $r['address_2'], '12' );
+	pr_dhl_assert( 'Long street stays within the 50 char addressStreet limit', strlen( $r['address_1'] ) <= 50, true );
+	pr_dhl_assert( 'Additional field stays within the 60 char limit', strlen( $r['address_additional'] ) <= 60, true );
+
+	// A short address_2 is a genuine house number and must be left untouched.
+	$r = pr_dhl_run_address( array( 'address_1' => 'Charles-de-Gaulle-Str.', 'address_2' => '20', 'country' => 'DE' ) );
+	pr_dhl_assert( 'Short address_2 kept as the house number', $r['address_2'], '20' );
+
+	// House number at the front of address_1.
+	$r = pr_dhl_run_address( array( 'address_1' => '20 Charles-de-Gaulle-Str', 'address_2' => '', 'country' => 'DE' ) );
+	pr_dhl_assert( 'Leading house number extracted', $r['address_2'], '20' );
+
+	echo $failures ? "\n{$failures} failure(s)\n" : "\nAll tests passed\n";
+	exit( $failures ? 1 : 0 );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

### Changes proposed in this Pull Request:

The consignee schema in `Item_Info.php` mapped `address_1 → addressStreet` with **no** length cap, while the shipper and return-address schemas already cap the street at 50 via `string_length_sanitization()`. When a customer's `address_1` exceeded 50 characters, DHL Parcel DE v2 returned `HTTP 400: addressStreet must be between 1 and 50 characters long`, blocking label creation until the merchant hand-edited the address.

This PR fits the address into DHL's field model instead of failing:

* Adds the missing `string_length_sanitization($value, 50)` cap on the consignee `addressStreet`, matching the shipper/return schemas.
* Adds `split_address_street()` (run after `set_address_2()`), which splits `address_1` at the last word boundary within 50 characters and routes the overflow to `additionalAddressInformation1` (max 60), so no apartment/floor data is lost:
  * `address_2` empty or ≤10 chars (house number) → overflow goes to the additional-address field, house number left untouched.
  * A single token longer than 50 chars with no space falls back to a hard cut at 50.
* Fixes the house-number loss when `address_2` is longer than 10 characters: `set_address_2()` previously moved the long `address_2` into the additional-address field and **returned before extracting the house number**, so `addressHouse` came back empty and DHL rejected the shipment with `400: Please enter a house number.` It now falls through and still recovers the trailing house number from `address_1` into `addressHouse`, while the relocated text (plus any street overflow) goes to the additional-address field.
* Packstation / parcelshop / post-office shipments are skipped (they use numeric locker IDs, not street lines).

Adds `tests/test-parcel-de-address.php`, a dependency-free script (run with `php tests/test-parcel-de-address.php`) that exercises `set_address_2()` / `split_address_street()` in isolation and covers both the long-`address_1` and long-`address_1`-plus-long-`address_2` cases.

ClickUp: https://app.clickup.com/t/868kghvz0

Closes #378 .

### How to test the changes in this Pull Request:

1. Create an order to a German address whose **Address line 1** is longer than 50 characters, e.g. `An der langen Mühlenstraße neben dem alten Wasserturm 12`.
2. Create a DHL Paket label for the order. Before this change the label fails with `addressStreet must be between 1 and 50 characters long`. With this change the label is created: the street is capped at 50 chars, the overflow appears in the additional address line, and the house number (`12`) is preserved in `addressHouse`.
3. Repeat with **Address line 2** also longer than 10 characters (set both Address line 1 and Address line 2 to `An der langen Mühlenstraße neben dem alten Wasserturm 12`). Before this change the label fails with `400: Please enter a house number.`; with this change the label is created with `addressHouse = 12` and the long address_2 text routed to the additional address line.
4. Optionally run `php tests/test-parcel-de-address.php` from the plugin directory and confirm all cases pass.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Fix: Create labels for orders whose street address is longer than 50 characters instead of failing; the extra text now moves to the additional address line.
