### PR TITLE
Fix CN22 customs value for fully discounted line items

### DIFF
--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -949,13 +949,10 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					continue;
 				}
 
-				// Value per item (not total), based on the ordered line so currency and discounts are respected.
-				$line_value = (float) $item['line_total'];
-
-				// If the line is fully discounted, declare the pre-discount subtotal instead of 0.
-				if ( $line_value <= 0 ) {
-					$line_value = (float) $item['line_subtotal'];
-				}
+				// Customs declares the pre-discount goods value: DHL ignores coupons and vouchers
+				// for customs, and a discounted (or 0) value is rejected. Use the line subtotal
+				// (before coupons) rather than the charged line total.
+				$line_value = (float) $item['line_subtotal'];
 
 				$new_item['item_value'] = ( $line_value / $item['qty'] );
 				// Sum the same per-line value so the package's declared total matches the per-item values.

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -949,10 +949,17 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					continue;
 				}
 
-				// Get 1 item value not total items, based on ordered items in case currency is different that set product price
-				$new_item['item_value'] = ( $item['line_total'] / $item['qty'] );
-				// Sum 'line_total' to get items total value w/ discounts!
-				$args['order_details']['items_value'] += $item['line_total'];
+				// Value per item (not total), based on the ordered line so currency and discounts are respected.
+				$line_value = (float) $item['line_total'];
+
+				// If the line is fully discounted, declare the pre-discount subtotal instead of 0.
+				if ( $line_value <= 0 ) {
+					$line_value = (float) $item['line_subtotal'];
+				}
+
+				$new_item['item_value'] = ( $line_value / $item['qty'] );
+				// Sum the same per-line value so the package's declared total matches the per-item values.
+				$args['order_details']['items_value'] += $line_value;
 
 				$product = wc_get_product( $item['product_id'] );
 
@@ -988,11 +995,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					$new_item['product_id'] = intval( $item['variation_id'] );
 					$new_item['sku']        = empty( $product_sku ) ? strval( $item['variation_id'] ) : $product_sku;
 
-					// If value is empty due to a full discount, use the pre-discount subtotal before the base price.
-					if ( empty( $new_item['item_value'] ) && ! empty( $item['line_subtotal'] ) ) {
-						$new_item['item_value'] = ( $item['line_subtotal'] / $item['qty'] );
-					}
-
 					// If value is empty due to discounts, set variation price instead
 					if ( empty( $new_item['item_value'] ) ) {
 						$new_item['item_value'] = $product_variation->get_price();
@@ -1009,11 +1011,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					// Ensure id is string and not int
 					$new_item['product_id'] = intval( $item['product_id'] );
 					$new_item['sku']        = empty( $product_sku ) ? strval( $item['product_id'] ) : $product_sku;
-
-					// If value is empty due to a full discount, use the pre-discount subtotal before the base price.
-					if ( empty( $new_item['item_value'] ) && ! empty( $item['line_subtotal'] ) ) {
-						$new_item['item_value'] = ( $item['line_subtotal'] / $item['qty'] );
-					}
 
 					// If value is empty due to discounts, set product price instead
 					if ( empty( $new_item['item_value'] ) ) {

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -988,6 +988,11 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					$new_item['product_id'] = intval( $item['variation_id'] );
 					$new_item['sku']        = empty( $product_sku ) ? strval( $item['variation_id'] ) : $product_sku;
 
+					// If value is empty due to a full discount, use the pre-discount subtotal before the base price.
+					if ( empty( $new_item['item_value'] ) && ! empty( $item['line_subtotal'] ) ) {
+						$new_item['item_value'] = ( $item['line_subtotal'] / $item['qty'] );
+					}
+
 					// If value is empty due to discounts, set variation price instead
 					if ( empty( $new_item['item_value'] ) ) {
 						$new_item['item_value'] = $product_variation->get_price();
@@ -1004,6 +1009,11 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					// Ensure id is string and not int
 					$new_item['product_id'] = intval( $item['product_id'] );
 					$new_item['sku']        = empty( $product_sku ) ? strval( $item['product_id'] ) : $product_sku;
+
+					// If value is empty due to a full discount, use the pre-discount subtotal before the base price.
+					if ( empty( $new_item['item_value'] ) && ! empty( $item['line_subtotal'] ) ) {
+						$new_item['item_value'] = ( $item['line_subtotal'] / $item['qty'] );
+					}
 
 					// If value is empty due to discounts, set product price instead
 					if ( empty( $new_item['item_value'] ) ) {

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -70,7 +70,7 @@ More detailed instructions on how to set up your store and configure it are cons
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
-* Fix: Show the correct customs value on the CN22 for a fully discounted line instead of using the product's base price.
+* Fix: Declare the full pre-discount goods value on the CN22 customs declaration so coupons and discounts no longer lower it or cause the label to fail.
 
 = 4.0.0 =
 * Drop SOAP API support.

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -70,6 +70,7 @@ More detailed instructions on how to set up your store and configure it are cons
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
+* Fix: Show the correct customs value on the CN22 for a fully discounted line instead of using the product's base price.
 
 = 4.0.0 =
 * Drop SOAP API support.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -78,6 +78,7 @@ More detailed instructions on how to set up your store and configure it are cons
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
+* Fix: Show the correct customs value on the CN22 for a fully discounted line instead of using the product's base price.
 
 = 4.0.0 =
 * Drop SOAP API support.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -78,7 +78,7 @@ More detailed instructions on how to set up your store and configure it are cons
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.
-* Fix: Show the correct customs value on the CN22 for a fully discounted line instead of using the product's base price.
+* Fix: Declare the full pre-discount goods value on the CN22 customs declaration so coupons and discounts no longer lower it or cause the label to fail.
 
 = 4.0.0 =
 * Drop SOAP API support.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow WooCommerce and WordPress standards?
* [x] Have you successfully run tests with your changes locally? (`php -l`; no unit-test suite in this repo)
* [ ] Have you tested both blocks/non-blocks cart/checkout? (N/A — admin-side label/customs logic, not checkout)
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest? (N/A)
* [ ] Have you successfully placed an order as both a logged-in user and a guest? (N/A)
* [ ] Did you have the query monitor plugin active during all testing?

### Changes proposed in this Pull Request:

Fixes the CN22 customs value declared for discounted order lines.

The customs value was taken from `line_total / qty` (the price actually charged, i.e. **after** coupons/discounts). DHL Parcel DE rejects this: a fully discounted line declared `itemValue: 0.00` and failed with _"The value must be greater than 0. Please note that discounts and payments via voucher are not relevant for customs declarations."_ — and even a partially discounted line declared the reduced value, which is wrong for customs for the same reason.

This sources the customs value from the **pre-discount line subtotal** (`line_subtotal / qty`, before coupons/vouchers) for every line, so discounts and vouchers never lower the declared goods value. The package `declaredValue` is summed from the same per-line value so the two stay consistent. A genuinely free product (`line_subtotal` is `0`) still falls through to the existing product-price fallback.

Closes #205.

ClickUp: https://app.clickup.com/t/868kghw31

### How to test the changes in this Pull Request:

1. Create a simple product with a price (e.g. 99).
2. Create an order to a customs destination (non-EU) and add the product.
3. **Full discount:** apply a 100% coupon/discount so the line total becomes `0` while the subtotal stays 99. Generate the DHL Paket international label (CN22). Expected: `itemValue` = `99.00` (from `line_subtotal`) and the label is created — previously it declared `0.00` and DHL rejected the shipment.
4. **Partial discount:** apply a partial discount (e.g. line total 42.52, subtotal 99). Generate the label. Expected: `itemValue` = `99.00` (the full pre-discount value), **not** the discounted 42.52.
5. **Regression:** a non-discounted order still declares the product's price; a genuinely free product (subtotal `0`) still falls back to the product price.

### Other information:

* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changelog entry

Fix: Declare the full pre-discount goods value on the CN22 customs declaration so coupons and discounts no longer lower it or cause the label to fail.
