### PR TITLE
Create bulk DHL labels in a single batched API request

### DIFF
--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -42,9 +42,12 @@ class Client extends API_Client {
 				if ( 200 === $item->sstatus->statusCode ) {
 					$labels_data['items'][] = $item;
 				} else {
+					$order_id                = isset( $item->shipmentRefNo )
+						? (int) str_replace( apply_filters( 'pr_shipping_dhl_paket_label_ref_no_prefix', 'order_' ), '', $item->shipmentRefNo )
+						: '';
 					$error_message           = $this->generate_error_message( $this->get_item_error_message( $item ) );
 					$labels_data['errors'][] = array(
-						'order_id' => '',
+						'order_id' => $order_id,
 						'message'  => wp_kses_post(
 							sprintf(
 							// Translators: %s is replaced with the error message returned from the API.

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -25,6 +25,7 @@ class Client extends API_Client {
 		$route = $this->request_order_route();
 		$data  = $this->request_info_to_request_data( $items_info );
 
+		// Request-level params (print format, combine, encoding) come from shared settings, so the first item represents the whole batch.
 		$route    = $this->add_request_params( $route, $items_info[0] );
 		$response = $this->post( $route, $data );
 

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -1268,9 +1268,10 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							array_push( $merge_files, PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] ) );
 						}
 					} catch ( Exception $e ) {
+						$order_number = $order ? $order->get_order_number() : $order_id;
 						$array_messages[] = array(
 							/* translators: %1$s is the order number, %2$s is the error message */
-							'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order->get_order_number() ), $e->getMessage() ),
+							'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order_number ), $e->getMessage() ),
 							'type'    => 'error',
 						);
 					}
@@ -1278,6 +1279,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 				// Create every deferred order in one API request, then map the results back per order.
 				if ( $use_batch && ! empty( $batch_args ) ) {
+					$handled_orders = array();
+
 					try {
 						$labels_result = $dhl_obj->get_dhl_labels( array_values( $batch_args ) );
 					} catch ( Exception $e ) {
@@ -1289,11 +1292,13 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						// A failure of the whole request applies to every queued order.
 						foreach ( array_keys( $batch_args ) as $failed_order_id ) {
 							$failed_order     = wc_get_order( $failed_order_id );
+							$order_number     = $failed_order ? $failed_order->get_order_number() : $failed_order_id;
 							$array_messages[] = array(
 								/* translators: %1$s is the order number, %2$s is the error message */
-								'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $failed_order->get_order_number() ), $e->getMessage() ),
+								'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order_number ), $e->getMessage() ),
 								'type'    => 'error',
 							);
+							$handled_orders[ $failed_order_id ] = true;
 						}
 					}
 
@@ -1304,6 +1309,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						if ( ! empty( $label_tracking_info['label_path'] ) ) {
 							array_push( $merge_files, PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] ) );
 						}
+
+						$handled_orders[ $label_tracking_info['order_id'] ] = true;
 					}
 
 					foreach ( $labels_result['errors'] as $error ) {
@@ -1314,6 +1321,23 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							'message' => wp_kses_post( sprintf( __( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), $order_number, $error['message'] ) ),
 							'type'    => 'error',
 						);
+
+						if ( ! empty( $error['order_id'] ) ) {
+							$handled_orders[ $error['order_id'] ] = true;
+						}
+					}
+
+					// Surface any queued order the API neither created nor reported, so nothing fails silently.
+					foreach ( array_keys( $batch_args ) as $order_id ) {
+						if ( empty( $handled_orders[ $order_id ] ) ) {
+							$order            = wc_get_order( $order_id );
+							$order_number     = $order ? $order->get_order_number() : $order_id;
+							$array_messages[] = array(
+								/* translators: %s is the order number */
+								'message' => sprintf( esc_html__( 'Order #%s: DHL label could not be created.', 'dhl-for-woocommerce' ), esc_html( $order_number ) ),
+								'type'    => 'error',
+							);
+						}
 					}
 				}
 				try {
@@ -1368,18 +1392,23 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		protected function save_created_dhl_label( $order_id, $label_tracking_info ) {
 			$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
 
-			$order              = wc_get_order( $order_id );
-			$tracking_note      = $this->get_tracking_note( $order_id );
-			$tracking_note_type = $this->get_tracking_note_type();
-			$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
+			$order = wc_get_order( $order_id );
 
-			$order->add_order_note( $tracking_note, $tracking_note_type, true );
+			if ( $order ) {
+				$tracking_note      = $this->get_tracking_note( $order_id );
+				$tracking_note_type = $this->get_tracking_note_type();
+				$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
+
+				$order->add_order_note( $tracking_note, $tracking_note_type, true );
+			}
 
 			do_action( 'pr_shipping_dhl_label_created', $order_id );
 
+			$order_number = $order ? $order->get_order_number() : $order_id;
+
 			return array(
 				/* translators: %s is the order number */
-				'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
+				'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order_number ),
 				'type'    => 'success',
 			);
 		}

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -1211,11 +1211,14 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			$label_count    = 0;
 			$merge_files    = array();
 			$array_messages = array();
-			$orders_args    = array();
 
 			if ( 'pr_dhl_create_labels' === $action ) {
 
 				$dhl_obj = PR_DHL()->get_dhl_factory();
+
+				// APIs exposing get_dhl_labels() create every selected order in a single request.
+				$use_batch  = method_exists( $dhl_obj, 'get_dhl_labels' );
+				$batch_args = array();
 
 				foreach ( $order_ids as $order_id ) {
 					$order = wc_get_order( $order_id );
@@ -1225,8 +1228,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						if ( empty( $label_tracking_info = $this->get_dhl_label_tracking( $order_id ) ) ) {
 
 							$this->save_default_dhl_label_items( $order_id );
-
-							// $dhl_label_items = $this->get_dhl_label_items( $order_id );
 
 							// Gather args for DHL API call
 							$args = $this->get_label_args( $order_id );
@@ -1251,25 +1252,16 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							// Allow third parties to modify the args to the DHL APIs
 							$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
 
+							// Defer to a single batched request when the API supports it.
+							if ( $use_batch ) {
+								$batch_args[ $order_id ] = $args;
+								continue;
+							}
+
 							// API request.
 							$label_tracking_info = $dhl_obj->get_dhl_label( $args );
-							$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
-							$tracking_note = $this->get_tracking_note( $order_id );
-
-							$tracking_note_type = $this->get_tracking_note_type();
-							$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
-
-							$order->add_order_note( $tracking_note, $tracking_note_type, true );
-
+							$array_messages[]    = $this->save_created_dhl_label( $order_id, $label_tracking_info );
 							++$label_count;
-
-							$array_messages[] = array(
-								/* translators: %s is the order number */
-								'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
-								'type'    => 'success',
-							);
-
-							do_action( 'pr_shipping_dhl_label_created', $order_id );
 						}
 
 						if ( ! empty( $label_tracking_info['label_path'] ) ) {
@@ -1279,6 +1271,47 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						$array_messages[] = array(
 							/* translators: %1$s is the order number, %2$s is the error message */
 							'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order->get_order_number() ), $e->getMessage() ),
+							'type'    => 'error',
+						);
+					}
+				}
+
+				// Create every deferred order in one API request, then map the results back per order.
+				if ( $use_batch && ! empty( $batch_args ) ) {
+					try {
+						$labels_result = $dhl_obj->get_dhl_labels( array_values( $batch_args ) );
+					} catch ( Exception $e ) {
+						$labels_result = array(
+							'labels' => array(),
+							'errors' => array(),
+						);
+
+						// A failure of the whole request applies to every queued order.
+						foreach ( array_keys( $batch_args ) as $failed_order_id ) {
+							$failed_order     = wc_get_order( $failed_order_id );
+							$array_messages[] = array(
+								/* translators: %1$s is the order number, %2$s is the error message */
+								'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $failed_order->get_order_number() ), $e->getMessage() ),
+								'type'    => 'error',
+							);
+						}
+					}
+
+					foreach ( $labels_result['labels'] as $label_tracking_info ) {
+						$array_messages[] = $this->save_created_dhl_label( $label_tracking_info['order_id'], $label_tracking_info );
+						++$label_count;
+
+						if ( ! empty( $label_tracking_info['label_path'] ) ) {
+							array_push( $merge_files, PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] ) );
+						}
+					}
+
+					foreach ( $labels_result['errors'] as $error ) {
+						$failed_order = wc_get_order( $error['order_id'] );
+						$order_number = $failed_order ? $failed_order->get_order_number() : $error['order_id'];
+						$array_messages[] = array(
+							/* translators: %1$s is the order number, %2$s is the error message */
+							'message' => wp_kses_post( sprintf( __( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), $order_number, $error['message'] ) ),
 							'type'    => 'error',
 						);
 					}
@@ -1321,6 +1354,34 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			return $array_messages;
+		}
+
+		/**
+		 * Persist a freshly created DHL label: store its tracking data, add the order note
+		 * and fire the label-created action.
+		 *
+		 * @param int   $order_id            The WooCommerce order ID.
+		 * @param array $label_tracking_info The tracking data returned by the DHL API.
+		 *
+		 * @return array The success message entry for the bulk action feedback.
+		 */
+		protected function save_created_dhl_label( $order_id, $label_tracking_info ) {
+			$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
+
+			$order              = wc_get_order( $order_id );
+			$tracking_note      = $this->get_tracking_note( $order_id );
+			$tracking_note_type = $this->get_tracking_note_type();
+			$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
+
+			$order->add_order_note( $tracking_note, $tracking_note_type, true );
+
+			do_action( 'pr_shipping_dhl_label_created', $order_id );
+
+			return array(
+				/* translators: %s is the order number */
+				'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
+				'type'    => 'success',
+			);
 		}
 
 		/**

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-paket.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-paket.php
@@ -56,7 +56,10 @@ class PR_DHL_API_Paket extends PR_DHL_API {
 	 */
 	public function get_dhl_labels( $multiple_orders_args ) {
 		$items_info = array();
-		$labels     = array();
+		$labels     = array(
+			'labels' => array(),
+			'errors' => array(),
+		);
 		$uom        = get_option( 'woocommerce_weight_unit' );
 
 		foreach ( $multiple_orders_args as $args ) {
@@ -72,22 +75,42 @@ class PR_DHL_API_Paket extends PR_DHL_API {
 			}
 		}
 
-		// Create the item and get the barcode
-		if ( ! empty( $items_info ) ) {
-			$items = $this->dhl_label->api_client->create_items( $items_info );
-			foreach ( $items['items'] as $item ) {
-				$order_id = (int) str_replace( apply_filters( 'pr_shipping_dhl_paket_label_ref_no_prefix', 'order_' ), '', $item->shipmentRefNo );
-				if ( isset( $item->label->b64 ) ) {
-					$file               = $this->dhl_label->save_data_file( 'label', $order_id, $item->label->b64 );
-					$labels['labels'][] = array(
-						'order_id'        => $order_id,
-						'label_path'      => $file['label_path'],
-						'tracking_number' => $item->shipmentNo,
-						'tracking_status' => '',
-					);
-				}
-			}
+		if ( empty( $items_info ) ) {
+			return $labels;
+		}
 
+		// Every shipment is created in a single API request.
+		$items = $this->dhl_label->api_client->create_items( $items_info );
+
+		// A multi-package order returns several shipments under the same order reference.
+		$items_by_order = array();
+		foreach ( $items['items'] as $item ) {
+			$order_id                      = (int) str_replace( apply_filters( 'pr_shipping_dhl_paket_label_ref_no_prefix', 'order_' ), '', $item->shipmentRefNo );
+			$items_by_order[ $order_id ][] = $item;
+		}
+
+		// Reuse the single-label save routines so return labels and customs documents are handled identically.
+		foreach ( $items_by_order as $order_id => $order_items ) {
+			try {
+				if ( count( $order_items ) > 1 ) {
+					$label_tracking_info = $this->dhl_label->save_multiple_shipments( 'label', $order_id, $order_items );
+				} else {
+					$label_tracking_info = $this->dhl_label->save_export_files( 'label', $order_id, $order_items[0] );
+				}
+
+				$label_tracking_info['order_id']        = $order_id;
+				$label_tracking_info['tracking_status'] = '';
+
+				$labels['labels'][] = $label_tracking_info;
+			} catch ( Exception $e ) {
+				$labels['errors'][] = array(
+					'order_id' => $order_id,
+					'message'  => $e->getMessage(),
+				);
+			}
+		}
+
+		if ( ! empty( $items['errors'] ) ) {
 			foreach ( $items['errors'] as $error ) {
 				$labels['errors'][] = array(
 					'order_id' => $error['order_id'],

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -67,6 +67,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.1.0 =
+* Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
+
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.1.0 =
+* Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
+
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

### Changes proposed in this Pull Request:

Bulk label creation looped over the selected orders and made **one synchronous DHL API call per order**, so large batches hit gateway/proxy timeouts (e.g. Cloudflare's 125s read timeout). The plugin already had a batch method (`PR_DHL_API_Paket::get_dhl_labels()`) that builds a single Parcel-DE `v2/orders` request for many shipments, but it was disabled during the 2023 REST/SOAP cleanup and never re-wired.

This PR turns bulk label creation into a single batched API request for DHL Paket:

* `process_bulk_actions()` now gathers each order's args, then issues **one** `get_dhl_labels()` call and maps the results back per order. Carriers without a batch method (Deutsche Post) transparently keep the per-order path via a `method_exists()` gate.
* `get_dhl_labels()` was rebuilt to batch only the API **call**, then run each order's returned shipments through the **same** `save_export_files()` / `save_multiple_shipments()` routines the single-label flow uses — so customs export docs, separate return labels and multi-package merging behave identically (no regression).
* Partial-failure (HTTP 207) errors are now attributed to their order number instead of a blank, and a whole-request failure surfaces an error against every queued order.

This raises the timeout ceiling dramatically (N requests → 1). Removing timeouts entirely at any batch size is the separate long-term Action Scheduler task.

ClickUp task: https://app.clickup.com/t/868kkyuk4

Closes # .

### How to test the changes in this Pull Request:

1. Configure valid DHL Paket REST API credentials (sandbox is fine).
2. Create several WooCommerce orders — include a mix of domestic, international (customs), and if possible a multi-package order and one with a separate return label enabled.
3. Go to **WooCommerce → Orders**, select the orders, and run the **DHL Create Labels** bulk action.
4. Confirm all labels are created in a single request (watch the network/API log — one `v2/orders` call), each order gets its tracking note, and the "download file" bulk link works.
5. Force a failure on one order (e.g. bad address / missing customs) and confirm the error message names that specific order while the others still succeed.
6. Repeat with a larger batch (a few dozen orders) and confirm it no longer times out.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
