### PR TITLE
Surface DHL warnings returned alongside successfully created labels

### DIFF
--- a/pr-dhl-woocommerce/assets/css/pr-dhl-admin.css
+++ b/pr-dhl-woocommerce/assets/css/pr-dhl-admin.css
@@ -14,6 +14,15 @@ ul.wc_dhl_error{
 	padding-left:20px;
 }
 
+.wc_dhl_label_message {
+	margin-top: 8px;
+	padding: 8px 10px;
+	color: #8a6d3b;
+	background: #fcf8e3;
+	border: 1px solid #faebcc;
+	border-radius: 3px;
+}
+
 .dhl_connection_succeeded {
 	color: #008000;
 	margin-left: 10px;

--- a/pr-dhl-woocommerce/assets/js/pr-dhl.js
+++ b/pr-dhl-woocommerce/assets/js/pr-dhl.js
@@ -408,6 +408,12 @@ jQuery( function( $ ) {
 						}
 						$( '#shipment-dhl-label-form' ).append(dhl_label_data.delete_label);
 
+						// Surface any non-blocking DHL warning returned alongside the created label.
+						$( '.wc_dhl_label_message' ).remove();
+						if ( response.label_message ) {
+							$( '#shipment-dhl-label-form' ).append( $('<p class="wc_dhl_label_message"></p>').text( response.label_message ) );
+						}
+
 						if( response.tracking_note ) {
 
 							$( '#woocommerce-order-notes' ).block({

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -30,7 +30,10 @@ class Client extends API_Client {
 
 		// Return the response body on success
 		if ( 200 === $response->status ) {
-			return array( 'items' => $response->body->items );
+			return array(
+				'items'    => $response->body->items,
+				'warnings' => $this->get_items_warnings( $response->body->items ),
+			);
 		}
 
 		if ( 207 === $response->status ) {
@@ -55,6 +58,8 @@ class Client extends API_Client {
 					);
 				}
 			}
+
+			$labels_data['warnings'] = $this->get_items_warnings( $labels_data['items'] );
 
 			return $labels_data;
 		}
@@ -512,6 +517,44 @@ class Client extends API_Client {
 		}
 
 		return $this->generate_error_message( $multiple_errors_list );
+	}
+
+	/**
+	 * Collects non-blocking (weak) validation warnings from successfully created labels.
+	 *
+	 * DHL returns these alongside a created label, for example when GoGreen Plus is booked
+	 * automatically through a standing order on the billing number. They must reach the
+	 * merchant even though the label itself was created without error.
+	 *
+	 * @param array $items Successfully created label items from the API response.
+	 *
+	 * @return string[] Warning messages, empty when there are none.
+	 */
+	protected function get_items_warnings( $items ) {
+		$warnings = array();
+
+		foreach ( $items as $item ) {
+			if ( empty( $item->validationMessages ) || ! is_array( $item->validationMessages ) ) {
+				continue;
+			}
+
+			foreach ( $item->validationMessages as $message ) {
+				// Hard errors are reported on the failure path; only surface weak validations here.
+				$state = $message->validationState ?? '';
+				if ( in_array( $state, array( 'Error', 'Invalid' ), true ) ) {
+					continue;
+				}
+
+				if ( empty( $message->validationMessage ) ) {
+					continue;
+				}
+
+				$property   = isset( $message->property ) ? '( ' . $message->property . ' ) : ' : '';
+				$warnings[] = $property . $message->validationMessage;
+			}
+		}
+
+		return $warnings;
 	}
 
 	/**

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -59,8 +59,8 @@ class Client extends API_Client {
 				}
 			}
 
-			$labels_data['warnings'] = $this->get_items_warnings( $labels_data['items'] );
-
+			// A 207 always carries at least one failed item, which get_dhl_label() rejects
+			// before any warning is surfaced, so weak warnings only matter on the 200 path.
 			return $labels_data;
 		}
 
@@ -520,11 +520,7 @@ class Client extends API_Client {
 	}
 
 	/**
-	 * Collects non-blocking (weak) validation warnings from successfully created labels.
-	 *
-	 * DHL returns these alongside a created label, for example when GoGreen Plus is booked
-	 * automatically through a standing order on the billing number. They must reach the
-	 * merchant even though the label itself was created without error.
+	 * Collect non-blocking (weak) validation warnings from successfully created labels.
 	 *
 	 * @param array $items Successfully created label items from the API response.
 	 *
@@ -554,7 +550,8 @@ class Client extends API_Client {
 			}
 		}
 
-		return $warnings;
+		// A standing-order warning repeats on every shipment of a multi-package order.
+		return array_values( array_unique( $warnings ) );
 	}
 
 	/**

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -377,6 +377,10 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 				do_action( 'pr_shipping_dhl_label_created', $order_id );
 
+				$label_message = ! empty( $label_tracking_info['dhl_label_warnings'] )
+					? implode( ' ', $label_tracking_info['dhl_label_warnings'] )
+					: '';
+
 				wp_send_json(
 					array(
 						'download_msg'       => esc_html__( 'Your DHL label is ready to download, click the "Download Label" button above"', 'dhl-for-woocommerce' ),
@@ -385,6 +389,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						'return_label_url'   => $this->get_download_return_label_url( $order_id ),
 						'tracking_note'      => $tracking_note,
 						'tracking_note_type' => $tracking_note_type,
+						'label_message'      => $label_message,
 					)
 				);
 
@@ -603,6 +608,9 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 * @return void
 		 */
 		public function save_dhl_label_tracking( $order_id, $tracking_items ) {
+
+			// Per-request label warnings are surfaced in the UI response, not stored on the order.
+			unset( $tracking_items['dhl_label_warnings'] );
 
 			if ( isset( $tracking_items['label_path'] ) && validate_file( $tracking_items['label_path'] ) === 2 ) {
 				$tracking_items['label_path'] = wp_slash( $tracking_items['label_path'] );

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-parcel-de.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-rest-parcel-de.php
@@ -103,6 +103,10 @@ class PR_DHL_API_REST_Parcel_DE extends PR_DHL_API_REST_Paket {
 			$label_tracking_info = $this->save_export_files( 'label', $args['order_details']['order_id'], $item_response['items'][0] );
 		}
 
+		if ( ! empty( $item_response['warnings'] ) ) {
+			$label_tracking_info['dhl_label_warnings'] = $item_response['warnings'];
+		}
+
 		return $label_tracking_info;
 	}
 

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -67,6 +67,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.1.0 =
+* Add: Show DHL warnings returned together with a successfully created label, such as when GoGreen Plus is added automatically through a standing order on the account.
+
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.1.0 =
+* Add: Show DHL warnings returned together with a successfully created label, such as when GoGreen Plus is added automatically through a standing order on the account.
+
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

_Cart/checkout items are not applicable: this change only affects the DHL label-creation flow in the order admin, not the storefront cart/checkout._

### Changes proposed in this Pull Request:

ClickUp task: https://app.clickup.com/t/868kmv7wf

While auditing the GoGreen → GoGreen Plus migration, legacy **GoGreen was confirmed already absent** from the plugin (settings, order UI, REST/SOAP mapping and the MyAccount sync) — there is nothing left to remove, and GoGreen Plus is fully wired for outbound labels and returns (`dhlRetoure.goGreenPlus`). The one real gap was that **DHL warnings returned alongside a *successfully* created label were silently dropped**.

When GoGreen Plus is booked automatically through a standing order on the billing number, DHL creates the label and returns a non-blocking ("weak") validation warning next to it. The response handler only read `validationMessages` on the failure path, so on a `200` (or a per-item success inside a `207`) those warnings never reached the merchant.

This PR surfaces them:

- `Client::create_items()` now collects weak validation warnings from successful items in both the `200` and `207` branches; hard errors still flow through the existing failure path unchanged.
- `get_dhl_label()` passes them up as `dhl_label_warnings`, which are returned in the label-metabox AJAX response and are **not** persisted to order meta.
- A small amber notice renders the warning under the label form.

### How to test the changes in this Pull Request:

1. In DHL Paket settings, use a sandbox account/billing number that has **GoGreen Plus as a standing order**.
2. Open a domestic order and create a DHL label with the **GoGreen Plus checkbox off**.
3. The label is created as normal, and a non-blocking warning now appears under the label form (e.g. that GoGreen Plus was added automatically), instead of being silently dropped.
4. Create a label on an account **without** a GoGreen Plus standing order and confirm no warning appears and nothing else changed.
5. Reload the order and confirm the warning is not persisted (label/tracking unaffected).

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

* Add: Show DHL warnings returned together with a successfully created label, such as when GoGreen Plus is added automatically through a standing order on the account.
