### PR TITLE
Extract shared per-order DHL label creation into a reusable method (ST1)

### DIFF
--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -364,18 +364,11 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				// Gather args for DHL API call
 				$args = $this->get_label_args( $order_id );
 
-				// Allow third parties to modify the args to the DHL APIs
-				$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
+				$this->create_dhl_label( $order_id, $args );
 
-				$dhl_obj             = PR_DHL()->get_dhl_factory();
-				$label_tracking_info = $dhl_obj->get_dhl_label( $args );
-
-				$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
 				$tracking_note      = $this->get_tracking_note( $order_id );
 				$tracking_note_type = $this->get_tracking_note_type();
 				$label_url          = $this->get_download_label_url( $order_id );
-
-				do_action( 'pr_shipping_dhl_label_created', $order_id );
 
 				wp_send_json(
 					array(
@@ -394,6 +387,33 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			wp_die();
+		}
+
+		/**
+		 * Creates a DHL label for a single order and persists its tracking data.
+		 *
+		 * Shared by the single-order and bulk label flows: applies the label-args
+		 * filter, calls the DHL API, saves the returned tracking data and fires the
+		 * label-created hook.
+		 *
+		 * @param int   $order_id Order ID.
+		 * @param array $args     Label args already gathered via get_label_args().
+		 *
+		 * @return array The label tracking info returned by the DHL API.
+		 * @throws Exception If the DHL API fails to create the label.
+		 */
+		protected function create_dhl_label( $order_id, $args ) {
+			// Allow third parties to modify the args to the DHL APIs
+			$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
+
+			$dhl_obj             = PR_DHL()->get_dhl_factory();
+			$label_tracking_info = $dhl_obj->get_dhl_label( $args );
+
+			$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
+
+			do_action( 'pr_shipping_dhl_label_created', $order_id );
+
+			return $label_tracking_info;
 		}
 
 		public function delete_label_ajax() {
@@ -1215,8 +1235,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 			if ( 'pr_dhl_create_labels' === $action ) {
 
-				$dhl_obj = PR_DHL()->get_dhl_factory();
-
 				foreach ( $order_ids as $order_id ) {
 					$order = wc_get_order( $order_id );
 
@@ -1248,13 +1266,9 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							// Allow settings to override saved order data, ONLY for bulk action
 							$args = $this->get_bulk_settings_override( $args );
 
-							// Allow third parties to modify the args to the DHL APIs
-							$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
-
 							// API request.
-							$label_tracking_info = $dhl_obj->get_dhl_label( $args );
-							$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
-							$tracking_note = $this->get_tracking_note( $order_id );
+							$label_tracking_info = $this->create_dhl_label( $order_id, $args );
+							$tracking_note       = $this->get_tracking_note( $order_id );
 
 							$tracking_note_type = $this->get_tracking_note_type();
 							$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
@@ -1268,8 +1282,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 								'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
 								'type'    => 'success',
 							);
-
-							do_action( 'pr_shipping_dhl_label_created', $order_id );
 						}
 
 						if ( ! empty( $label_tracking_info['label_path'] ) ) {

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
@@ -680,15 +680,8 @@ class PR_DHL_WC_Order_Deutsche_Post extends PR_DHL_WC_Order {
 			// Gather args for DHL API call
 			$args = $this->get_label_args( $order_id );
 
-			// Allow third parties to modify the args to the DHL APIs
-			$args       = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
-			$dhl_obj    = PR_DHL()->get_dhl_factory();
-			$label_info = $dhl_obj->get_dhl_label( $args );
-
-			$this->save_dhl_label_tracking( $order_id, $label_info );
+			$this->create_dhl_label( $order_id, $args );
 			$label_url = $this->get_download_label_url( $order_id );
-
-			do_action( 'pr_shipping_dhl_label_created', $order_id );
 
 			wp_send_json(
 				array(


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you tested both blocks/non-blocks cart/checkout?
* [ ] Have you tested the cart and checkout as both a logged-in user and a guest?
* [ ] Have you successfully placed an order as both a logged-in user and a guest?
* [ ] Did you have the query monitor plugin active during all testing?

_Cart/checkout items are not applicable: this is an internal refactor of the admin label-creation flow with no storefront or behavior change._

### Changes proposed in this Pull Request:

ClickUp task: https://app.clickup.com/t/868kn4pe3 (ST1 of https://app.clickup.com/t/868kkyukv)

Groundwork for moving label creation to background processing (Action Scheduler). This is a **pure, behavior-preserving refactor** — no functional change.

The per-order label-creation tail (`apply_filters( 'pr_shipping_dhl_label_args' )` → `get_dhl_factory()->get_dhl_label()` → `save_dhl_label_tracking()` → `do_action( 'pr_shipping_dhl_label_created' )`) was duplicated in three places. It is now extracted into one reusable method, `PR_DHL_WC_Order::create_dhl_label( $order_id, $args )`, which the later async work (ST2+) will enqueue as a job.

- `save_meta_box_ajax()` (single-order) now calls `create_dhl_label()`.
- `process_bulk_actions()` (bulk loop) now calls `create_dhl_label()`; the now-dead `$dhl_obj` local and the duplicated `do_action()` were removed.
- `PR_DHL_WC_Order_Deutsche_Post::save_meta_box_ajax()` (the DP override) now calls `create_dhl_label()`.

Ordering is preserved everywhere — in the bulk path `get_bulk_settings_override()` still runs before the `pr_shipping_dhl_label_args` filter (now applied inside the method). The "create label on order status" path routes through `process_bulk_actions()`, so it inherits the change with no separate edit.

Targets the long-lived `feature/label-background-processing` branch, not `master` (feature is under a release freeze pending approval).

Closes # .

### How to test the changes in this Pull Request:

1. Open a single order and create a DHL Paket label from the order metabox — label is created, tracking saved, order status transitions exactly as before.
2. Select several orders and run the **Create DHL labels** bulk action — all labels are created, the merged "download file" link appears, and per-order success/error notices are unchanged.
3. With "Create label on order status" enabled, move an order to the configured status — the label is created (this path runs through the bulk handler).
4. Create a Deutsche Post label from its order metabox — label is created and downloadable as before.
5. Confirm no PHP notices/errors with Query Monitor active.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

No changelog entry — internal refactor with no user-facing behavior change.
