### PR TITLE
Background label processing: chunked Action Scheduler bulk jobs

### DIFF
--- a/pr-dhl-woocommerce/assets/js/pr-dhl-bulk-progress.js
+++ b/pr-dhl-woocommerce/assets/js/pr-dhl-bulk-progress.js
@@ -1,0 +1,141 @@
+/**
+ * Live progress panel for background bulk DHL label creation on the WooCommerce Orders screen.
+ *
+ * Polls the batch-progress AJAX endpoint, updates a progress bar, and once every job has settled
+ * exposes "Download all labels" (merged PDF), "Retry failed" and "Dismiss" actions.
+ */
+( function ( $ ) {
+	'use strict';
+
+	var cfg = window.prDhlLabelBatch || {};
+	var $panel = $( '#pr-dhl-label-batch' );
+
+	if ( ! $panel.length || ! cfg.ajaxUrl ) {
+		return;
+	}
+
+	var i18n     = cfg.i18n || {};
+	var $title   = $panel.find( '.pr-dhl-label-batch__title strong' );
+	var $fill    = $panel.find( '.pr-dhl-label-batch__fill' );
+	var $status  = $panel.find( '.pr-dhl-label-batch__status' );
+	var $actions = $panel.find( '.pr-dhl-label-batch__actions' );
+	var $download = $panel.find( '.pr-dhl-label-batch__download' );
+	var $retry   = $panel.find( '.pr-dhl-label-batch__retry' );
+	var $dismiss = $panel.find( '.pr-dhl-label-batch__dismiss' );
+
+	var timer = null;
+	var downloading = false;
+
+	function format( tpl, a, b, c ) {
+		return String( tpl ).replace( '%1$d', a ).replace( '%2$d', b ).replace( '%3$d', c );
+	}
+
+	function post( action, extra ) {
+		return $.post( cfg.ajaxUrl, $.extend( { action: action, nonce: cfg.nonce }, extra || {} ) );
+	}
+
+	function stop() {
+		if ( timer ) {
+			window.clearInterval( timer );
+			timer = null;
+		}
+	}
+
+	function start() {
+		stop();
+		timer = window.setInterval( poll, cfg.interval || 5000 );
+	}
+
+	function render( data ) {
+		if ( ! data || ! data.active ) {
+			stop();
+			$panel.hide();
+			return;
+		}
+
+		$panel.show();
+
+		var handled = data.created + data.failed;
+		var pct = data.total ? Math.round( ( handled / data.total ) * 100 ) : 0;
+		$fill.css( 'width', pct + '%' );
+		$status.text( format( i18n.status, data.created, data.failed, data.pending ) );
+
+		if ( data.stalled ) {
+			stop();
+			$title.text( i18n.stalled );
+			$panel.removeClass( 'notice-info' ).addClass( 'notice-warning' );
+			$download.toggle( !! data.can_download );
+			$retry.toggle( !! data.has_failed );
+			$actions.show();
+			return;
+		}
+
+		if ( ! data.done ) {
+			$title.text( i18n.creating );
+			$actions.hide();
+			return;
+		}
+
+		stop();
+		$title.text( data.has_failed ? i18n.doneErrors : i18n.doneOk );
+		$panel.removeClass( 'notice-info' ).addClass( data.has_failed ? 'notice-warning' : 'notice-success' );
+		$download.toggle( !! data.can_download );
+		$retry.toggle( !! data.has_failed );
+		$actions.show();
+	}
+
+	function poll() {
+		post( 'pr_dhl_label_batch_progress' ).done( function ( res ) {
+			if ( res && res.success ) {
+				render( res.data );
+			}
+		} );
+	}
+
+	$download.on( 'click', function ( e ) {
+		e.preventDefault();
+
+		if ( downloading ) {
+			return;
+		}
+		downloading = true;
+
+		post( 'pr_dhl_label_batch_download' ).done( function ( res ) {
+			if ( res && res.success && res.data && res.data.url ) {
+				window.location.href = res.data.url;
+			} else {
+				$status.text( ( res && res.data && res.data.message ) || i18n.error );
+			}
+		} ).fail( function () {
+			$status.text( i18n.error );
+		} ).always( function () {
+			downloading = false;
+		} );
+	} );
+
+	$retry.on( 'click', function ( e ) {
+		e.preventDefault();
+
+		post( 'pr_dhl_label_batch_retry' ).done( function ( res ) {
+			if ( ! res || ! res.success ) {
+				$status.text( ( res && res.data && res.data.message ) || i18n.error );
+				return;
+			}
+
+			$panel.removeClass( 'notice-success notice-warning' ).addClass( 'notice-info' );
+			$actions.hide();
+			poll();
+			start();
+		} );
+	} );
+
+	$dismiss.on( 'click', function ( e ) {
+		e.preventDefault();
+		stop();
+		post( 'pr_dhl_label_batch_dismiss' );
+		$panel.slideUp();
+	} );
+
+	poll();
+	start();
+} )( jQuery );

--- a/pr-dhl-woocommerce/assets/js/pr-dhl-bulk-progress.js
+++ b/pr-dhl-woocommerce/assets/js/pr-dhl-bulk-progress.js
@@ -87,8 +87,19 @@
 				if ( j ) {
 					$li.append( document.createTextNode( ', ' ) );
 				}
-				$( '<a/>', { href: f.edit_url, target: '_blank', rel: 'noopener' } ).text( '#' + f.number ).appendTo( $li );
+				var $ref = $( '<a/>', { target: '_blank', rel: 'noopener' } ).text( '#' + f.number );
+				if ( f.edit_url ) {
+					$ref.attr( 'href', f.edit_url );
+				}
+				$ref.appendTo( $li );
 			} );
+
+			// Per-group guidance: is this a "just Retry" transient error or a "fix the order first" one?
+			var hint = items[ 0 ].category === 'transient' ? i18n.catTransient
+				: ( items[ 0 ].category === 'action' ? i18n.catAction : '' );
+			if ( hint ) {
+				$( '<em/>' ).css( { display: 'block', opacity: 0.8 } ).text( hint ).appendTo( $li );
+			}
 
 			$li.appendTo( $list );
 		} );

--- a/pr-dhl-woocommerce/assets/js/pr-dhl-bulk-progress.js
+++ b/pr-dhl-woocommerce/assets/js/pr-dhl-bulk-progress.js
@@ -18,6 +18,7 @@
 	var $title   = $panel.find( '.pr-dhl-label-batch__title strong' );
 	var $fill    = $panel.find( '.pr-dhl-label-batch__fill' );
 	var $status  = $panel.find( '.pr-dhl-label-batch__status' );
+	var $details = $panel.find( '.pr-dhl-label-batch__details' );
 	var $actions = $panel.find( '.pr-dhl-label-batch__actions' );
 	var $download = $panel.find( '.pr-dhl-label-batch__download' );
 	var $retry   = $panel.find( '.pr-dhl-label-batch__retry' );
@@ -46,6 +47,57 @@
 		timer = window.setInterval( poll, cfg.interval || 5000 );
 	}
 
+	function renderFailures( data ) {
+		$details.empty();
+
+		var failures = data.failures || [];
+		if ( ! failures.length ) {
+			return;
+		}
+
+		// Flag that some failed orders may already have a label at DHL and must not be blindly retried.
+		var anyPurchased = false;
+
+		// Group identical failure messages so a systematic cause (e.g. one bad setting) reads as
+		// "10× <reason>" rather than ten separate lines.
+		var groups = {};
+		var order = [];
+		$.each( failures, function ( i, f ) {
+			if ( f.purchased ) {
+				anyPurchased = true;
+			}
+			if ( ! groups[ f.message ] ) {
+				groups[ f.message ] = [];
+				order.push( f.message );
+			}
+			groups[ f.message ].push( f );
+		} );
+
+		$( '<p/>' ).css( 'margin', '4px 0 2px' ).append( $( '<strong/>' ).text( i18n.failTitle ) ).appendTo( $details );
+
+		var $list = $( '<ul/>' ).css( { margin: '0 0 4px 18px', 'list-style': 'disc' } ).appendTo( $details );
+
+		$.each( order, function ( i, message ) {
+			var items = groups[ message ];
+			var $li = $( '<li/>' );
+			$( '<strong/>' ).text( items.length + '× ' ).appendTo( $li );
+			$li.append( document.createTextNode( message + ' — ' ) );
+
+			$.each( items, function ( j, f ) {
+				if ( j ) {
+					$li.append( document.createTextNode( ', ' ) );
+				}
+				$( '<a/>', { href: f.edit_url, target: '_blank', rel: 'noopener' } ).text( '#' + f.number ).appendTo( $li );
+			} );
+
+			$li.appendTo( $list );
+		} );
+
+		if ( anyPurchased ) {
+			$( '<p/>' ).css( { margin: '4px 0', color: '#8a6d00' } ).text( i18n.purchased ).appendTo( $details );
+		}
+	}
+
 	function render( data ) {
 		if ( ! data || ! data.active ) {
 			stop();
@@ -59,13 +111,14 @@
 		var pct = data.total ? Math.round( ( handled / data.total ) * 100 ) : 0;
 		$fill.css( 'width', pct + '%' );
 		$status.text( format( i18n.status, data.created, data.failed, data.pending ) );
+		renderFailures( data );
 
 		if ( data.stalled ) {
 			stop();
 			$title.text( i18n.stalled );
 			$panel.removeClass( 'notice-info' ).addClass( 'notice-warning' );
 			$download.toggle( !! data.can_download );
-			$retry.toggle( !! data.has_failed );
+			$retry.toggle( !! data.retryable );
 			$actions.show();
 			return;
 		}
@@ -80,7 +133,7 @@
 		$title.text( data.has_failed ? i18n.doneErrors : i18n.doneOk );
 		$panel.removeClass( 'notice-info' ).addClass( data.has_failed ? 'notice-warning' : 'notice-success' );
 		$download.toggle( !! data.can_download );
-		$retry.toggle( !! data.has_failed );
+		$retry.toggle( !! data.retryable );
 		$actions.show();
 	}
 

--- a/pr-dhl-woocommerce/includes/REST_API/Drivers/WP_API_Driver.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Drivers/WP_API_Driver.php
@@ -37,14 +37,14 @@ class WP_API_Driver implements API_Driver_Interface {
 				'body'       => $request->body,
 				'headers'    => $request->headers,
 				'cookies'    => $request->cookies,
-				'timeout'    => self::WP_REQUEST_TIMEOUT,
+				'timeout'    => (int) apply_filters( 'pr_dhl_api_request_timeout', self::WP_REQUEST_TIMEOUT ),
 				'user-agent' => 'WooCommerce/' . WC_VERSION . ' (WordPress/' . get_bloginfo( 'version' ) . ') DHL-plug-in/' . PR_DHL_VERSION,
 			)
 		);
 
 		// Check if an error occurred
 		if ( is_wp_error( $response ) ) {
-			throw new RuntimeException( esc_html__( $response->get_error_message(), 'dhl-for-woocommerce' ) );
+			throw new RuntimeException( esc_html( $response->get_error_message() ) );
 		}
 
 		// Retrieve the headers from the response

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -42,9 +42,12 @@ class Client extends API_Client {
 				if ( 200 === $item->sstatus->statusCode ) {
 					$labels_data['items'][] = $item;
 				} else {
+					$order_id                = isset( $item->shipmentRefNo )
+						? (int) str_replace( apply_filters( 'pr_shipping_dhl_paket_label_ref_no_prefix', 'order_' ), '', $item->shipmentRefNo )
+						: '';
 					$error_message           = $this->generate_error_message( $this->get_item_error_message( $item ) );
 					$labels_data['errors'][] = array(
-						'order_id' => '',
+						'order_id' => $order_id,
 						'message'  => wp_kses_post(
 							sprintf(
 							// Translators: %s is replaced with the error message returned from the API.

--- a/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
+++ b/pr-dhl-woocommerce/includes/REST_API/Parcel_DE/Client.php
@@ -25,6 +25,7 @@ class Client extends API_Client {
 		$route = $this->request_order_route();
 		$data  = $this->request_info_to_request_data( $items_info );
 
+		// Request-level params (print format, combine, encoding) come from shared settings, so the first item represents the whole batch.
 		$route    = $this->add_request_params( $route, $items_info[0] );
 		$response = $this->post( $route, $data );
 

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -540,7 +540,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			if ( empty( $pending_orders ) ) {
 				return array(
 					array(
-						'message' => esc_html__( 'The selected orders already have DHL labels.', 'dhl-for-woocommerce' ),
+						'message' => esc_html__( 'No orders needed queuing — the selected orders already have a DHL label or a background job in progress.', 'dhl-for-woocommerce' ),
 						'type'    => 'warning',
 					),
 				);
@@ -598,7 +598,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			if ( empty( $pending_orders ) ) {
 				return array(
 					array(
-						'message' => esc_html__( 'The selected orders already have DHL labels.', 'dhl-for-woocommerce' ),
+						'message' => esc_html__( 'No orders needed queuing — the selected orders already have a DHL label or a background job in progress.', 'dhl-for-woocommerce' ),
 						'type'    => 'warning',
 					),
 				);
@@ -708,7 +708,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							/* translators: %s is the storage error message */
 							esc_html__( 'DHL created the label but it could not be saved (%s). A label may already exist at DHL — verify before retrying.', 'dhl-for-woocommerce' ),
 							$e->getMessage()
-						)
+						),
+						array( 'purchased' => true )
 					);
 				}
 
@@ -735,11 +736,14 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 *
 		 * @param int    $order_id Order ID.
 		 * @param string $message  Failure reason.
+		 * @param array  $context  Optional extra job-state context, e.g. 'purchased' => true when the label
+		 *                         was bought at DHL but could not be saved locally.
 		 *
 		 * @return void
 		 */
-		protected function record_async_label_failure( $order_id, $message ) {
-			$this->set_label_job_status( $order_id, self::JOB_FAILED, array( 'message' => $message ) );
+		protected function record_async_label_failure( $order_id, $message, $context = array() ) {
+			$context['message'] = $message;
+			$this->set_label_job_status( $order_id, self::JOB_FAILED, $context );
 
 			$order = wc_get_order( $order_id );
 
@@ -759,7 +763,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 *
 		 * @param int    $order_id Order ID.
 		 * @param string $status   One of self::JOB_PENDING, self::JOB_CREATED, self::JOB_FAILED.
-		 * @param array  $context  Optional 'message' (failure reason) and 'warnings' (string[]).
+		 * @param array  $context  Optional 'message' (failure reason), 'warnings' (string[]) and
+		 *                         'purchased' (bool: the label was bought at DHL but could not be saved).
 		 *
 		 * @return void
 		 */
@@ -773,9 +778,10 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			$order->update_meta_data(
 				self::JOB_STATUS_META,
 				array(
-					'status'   => $status,
-					'message'  => isset( $context['message'] ) ? $context['message'] : '',
-					'warnings' => isset( $context['warnings'] ) ? (array) $context['warnings'] : array(),
+					'status'    => $status,
+					'message'   => isset( $context['message'] ) ? $context['message'] : '',
+					'warnings'  => isset( $context['warnings'] ) ? (array) $context['warnings'] : array(),
+					'purchased' => ! empty( $context['purchased'] ),
 				)
 			);
 			$order->save_meta_data();
@@ -786,13 +792,14 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 *
 		 * @param int $order_id Order ID.
 		 *
-		 * @return array{status: string, message: string, warnings: array} Empty status when no job has run.
+		 * @return array{status: string, message: string, warnings: array, purchased: bool} Empty status when no job has run.
 		 */
 		public function get_label_job_status( $order_id ) {
 			$default = array(
-				'status'   => '',
-				'message'  => '',
-				'warnings' => array(),
+				'status'    => '',
+				'message'   => '',
+				'warnings'  => array(),
+				'purchased' => false,
 			);
 
 			$order = wc_get_order( $order_id );
@@ -840,7 +847,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			if ( self::JOB_FAILED === $job['status'] ) {
 				$message = '' !== $job['message']
 					? $job['message']
-					: esc_html__( 'The DHL label could not be created.', 'dhl-for-woocommerce' );
+					: __( 'The DHL label could not be created.', 'dhl-for-woocommerce' );
 
 				return '<p class="wc_dhl_error wc_dhl_label_job wc_dhl_label_job--failed">'
 					. sprintf(
@@ -1808,39 +1815,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						}
 					}
 				}
-				try {
-					$file_bulk = $this->merge_label_files( $merge_files );
-
-					if ( file_exists( $file_bulk['file_bulk_path'] ) ) {
-						// We're saving the bulk file path temporarily and access it later during the download process.
-						// This information expires in 3 minutes (180 seconds), just enough for the user to see the
-						// displayed link and click it if he or she wishes to download the bulk labels
-						set_transient(
-							'_dhl_bulk_download_labels_file_' . get_current_user_id(),
-							$file_bulk['file_bulk_path'],
-							180
-						);
-
-						// Construct URL pointing to the download label endpoint (with bulk param):
-						$bulk_download_label_url = $this->generate_download_url( '/' . self::DHL_DOWNLOAD_ENDPOINT . '/bulk' );
-
-						$array_messages[] = array(
-							/* translators: %1$s and %2$s are HTML tags for the download link */
-							'message' => wp_kses_post( sprintf( __( 'Bulk DHL labels file created - %1$sdownload file%2$s', 'dhl-for-woocommerce' ), '<a href="' . esc_url( $bulk_download_label_url ) . '" download>', '</a>' ) ),
-							'type'    => 'success',
-						);
-					} else {
-						$array_messages[] = array(
-							'message' => esc_html__( 'Could not create bulk DHL label file, download individually.', 'dhl-for-woocommerce' ),
-							'type'    => 'error',
-						);
-					}
-				} catch ( Exception $e ) {
-					$array_messages[] = array(
-						'message' => wp_kses_post( $e->getMessage() ),
-						'type'    => 'error',
-					);
-				}
+				$array_messages = array_merge( $array_messages, $this->build_merged_label_message( $merge_files ) );
 			} elseif ( 'pr_dhl_retry_failed_labels' === $action ) {
 				$array_messages = $this->retry_failed_label_jobs( $order_ids );
 			} elseif ( 'pr_dhl_download_labels' === $action ) {
@@ -1862,28 +1837,55 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 * @return array Bulk-action feedback messages.
 		 */
 		protected function retry_failed_label_jobs( $order_ids ) {
-			$failed_orders = array();
+			$failed_orders    = array();
+			$purchased_orders = array();
 
 			foreach ( $order_ids as $order_id ) {
 				if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
 					continue;
 				}
 
-				if ( self::JOB_FAILED === $this->get_label_job_status( $order_id )['status'] ) {
-					$failed_orders[] = $order_id;
+				$job = $this->get_label_job_status( $order_id );
+
+				if ( self::JOB_FAILED !== $job['status'] ) {
+					continue;
 				}
+
+				// A label that was bought at DHL but failed to save must not be re-created blindly:
+				// retrying would purchase a second label. Leave it for manual verification.
+				if ( ! empty( $job['purchased'] ) ) {
+					$purchased_orders[] = $order_id;
+					continue;
+				}
+
+				$failed_orders[] = $order_id;
 			}
 
-			if ( empty( $failed_orders ) ) {
-				return array(
-					array(
-						'message' => esc_html__( 'No failed DHL label jobs were found in the selected orders.', 'dhl-for-woocommerce' ),
-						'type'    => 'warning',
+			$array_messages = array();
+
+			if ( ! empty( $purchased_orders ) ) {
+				$array_messages[] = array(
+					'message' => sprintf(
+						/* translators: %d is the number of orders skipped */
+						esc_html( _n( '%d order was not retried because a label may already exist at DHL — verify it before retrying.', '%d orders were not retried because a label may already exist at DHL — verify them before retrying.', count( $purchased_orders ), 'dhl-for-woocommerce' ) ),
+						count( $purchased_orders )
 					),
+					'type'    => 'warning',
 				);
 			}
 
-			return $this->process_bulk_actions( 'pr_dhl_create_labels', $failed_orders );
+			if ( empty( $failed_orders ) ) {
+				if ( empty( $array_messages ) ) {
+					$array_messages[] = array(
+						'message' => esc_html__( 'No failed DHL label jobs were found in the selected orders.', 'dhl-for-woocommerce' ),
+						'type'    => 'warning',
+					);
+				}
+
+				return $array_messages;
+			}
+
+			return array_merge( $array_messages, $this->process_bulk_actions( 'pr_dhl_create_labels', $failed_orders ) );
 		}
 
 		/**
@@ -1915,6 +1917,19 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				);
 			}
 
+			return $this->build_merged_label_message( $merge_files );
+		}
+
+		/**
+		 * Merges the given label files into one PDF, stashes its path in a short-lived per-user transient
+		 * and returns the download-link (or error) message. Shared by the synchronous bulk-create fallback
+		 * and the "Download DHL Labels" bulk action so the transient key, TTL and copy live in one place.
+		 *
+		 * @param array $merge_files Absolute paths of the label files to merge.
+		 *
+		 * @return array Bulk-action feedback messages.
+		 */
+		protected function build_merged_label_message( $merge_files ) {
 			try {
 				$file_bulk = $this->merge_label_files( $merge_files );
 
@@ -1927,6 +1942,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					);
 				}
 
+				// Stash the merged file path for the download endpoint. Expires in 3 minutes: long enough
+				// for the user to see the link and click it.
 				set_transient(
 					'_dhl_bulk_download_labels_file_' . get_current_user_id(),
 					$file_bulk['file_bulk_path'],

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -23,6 +23,12 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		const ACTION_CREATE_LABEL = 'pr_dhl_create_label_async';
 		const ACTION_GROUP        = 'pr-dhl-labels';
 
+		// Per-order background label job state.
+		const JOB_STATUS_META = '_pr_dhl_label_job';
+		const JOB_PENDING     = 'pending';
+		const JOB_CREATED     = 'created';
+		const JOB_FAILED      = 'failed';
+
 		protected $shipping_dhl_settings = array();
 
 		protected $service = 'DHL';
@@ -457,6 +463,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			as_enqueue_async_action( self::ACTION_CREATE_LABEL, array( $order_id ), self::ACTION_GROUP );
+			$this->set_label_job_status( $order_id, self::JOB_PENDING );
 
 			return true;
 		}
@@ -475,6 +482,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		public function create_label_async( $order_id ) {
 			// Skip if a label has already been created for this order.
 			if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
+				$this->set_label_job_status( $order_id, self::JOB_CREATED );
+
 				return;
 			}
 
@@ -483,8 +492,18 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 				$args = $this->get_label_args( $order_id );
 
-				$this->create_dhl_label( $order_id, $args );
+				$label_tracking_info = $this->create_dhl_label( $order_id, $args );
+
+				$this->set_label_job_status(
+					$order_id,
+					self::JOB_CREATED,
+					array(
+						'warnings' => isset( $label_tracking_info['dhl_label_warnings'] ) ? $label_tracking_info['dhl_label_warnings'] : array(),
+					)
+				);
 			} catch ( Exception $e ) {
+				$this->set_label_job_status( $order_id, self::JOB_FAILED, array( 'message' => $e->getMessage() ) );
+
 				$order = wc_get_order( $order_id );
 
 				if ( $order instanceof WC_Order ) {
@@ -497,6 +516,62 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					);
 				}
 			}
+		}
+
+		/**
+		 * Records the background label job state for an order.
+		 *
+		 * @param int    $order_id Order ID.
+		 * @param string $status   One of self::JOB_PENDING, self::JOB_CREATED, self::JOB_FAILED.
+		 * @param array  $context  Optional 'message' (failure reason) and 'warnings' (string[]).
+		 *
+		 * @return void
+		 */
+		public function set_label_job_status( $order_id, $status, $context = array() ) {
+			$order = wc_get_order( $order_id );
+
+			if ( ! $order instanceof WC_Order ) {
+				return;
+			}
+
+			$order->update_meta_data(
+				self::JOB_STATUS_META,
+				array(
+					'status'   => $status,
+					'message'  => isset( $context['message'] ) ? $context['message'] : '',
+					'warnings' => isset( $context['warnings'] ) ? (array) $context['warnings'] : array(),
+				)
+			);
+			$order->save_meta_data();
+		}
+
+		/**
+		 * Returns the background label job state for an order.
+		 *
+		 * @param int $order_id Order ID.
+		 *
+		 * @return array{status: string, message: string, warnings: array} Empty status when no job has run.
+		 */
+		public function get_label_job_status( $order_id ) {
+			$default = array(
+				'status'   => '',
+				'message'  => '',
+				'warnings' => array(),
+			);
+
+			$order = wc_get_order( $order_id );
+
+			if ( ! $order instanceof WC_Order ) {
+				return $default;
+			}
+
+			$status = $order->get_meta( self::JOB_STATUS_META );
+
+			if ( ! is_array( $status ) ) {
+				return $default;
+			}
+
+			return wp_parse_args( $status, $default );
 		}
 
 		public function delete_label_ajax() {

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -481,6 +481,70 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		}
 
 		/**
+		 * MySQL named-lock name for an order's label creation. Named locks are global to the DB server, so
+		 * the table prefix keeps two sites on one server from colliding.
+		 *
+		 * @param int $order_id Order ID.
+		 *
+		 * @return string
+		 */
+		protected function order_label_lock_name( $order_id ) {
+			global $wpdb;
+
+			return $wpdb->prefix . 'pr_dhl_label_' . (int) $order_id;
+		}
+
+		/**
+		 * Best-effort cross-process claim on an order's label creation, so two concurrent background jobs
+		 * (or a job racing a manual retry) cannot both purchase a label for the same order. Returns true
+		 * when the caller holds the claim (and must release it), or when locking is unavailable — in which
+		 * case we degrade to the existing tracking/pending guards rather than block label creation.
+		 *
+		 * @param int $order_id Order ID.
+		 *
+		 * @return bool
+		 */
+		protected function claim_order_label_lock( $order_id ) {
+			global $wpdb;
+
+			// GET_LOCK returns 1 (acquired), 0 (held elsewhere), or NULL (error/unsupported).
+			$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 0)', $this->order_label_lock_name( $order_id ) ) );
+
+			if ( null === $result ) {
+				return true;
+			}
+
+			return '1' === (string) $result;
+		}
+
+		/**
+		 * Releases an order's label claim. Named locks also auto-release when the DB session ends, so this
+		 * is a tidy early release rather than the only safety net.
+		 *
+		 * @param int $order_id Order ID.
+		 *
+		 * @return void
+		 */
+		protected function release_order_label_lock( $order_id ) {
+			global $wpdb;
+
+			$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $this->order_label_lock_name( $order_id ) ) );
+		}
+
+		/**
+		 * Releases several order label claims.
+		 *
+		 * @param array $order_ids Order IDs.
+		 *
+		 * @return void
+		 */
+		protected function release_order_label_locks( array $order_ids ) {
+			foreach ( $order_ids as $order_id ) {
+				$this->release_order_label_lock( $order_id );
+			}
+		}
+
+		/**
 		 * Action Scheduler callback: create a DHL label for one order in the background.
 		 *
 		 * Rebuilds the label args from the stored order data rather than relying on a
@@ -507,48 +571,64 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				return;
 			}
 
-			// Build the request. A failure here is before any purchase, so the order is safe to retry.
-			try {
-				$this->save_default_dhl_label_items( $order_id );
-				$args = $this->get_label_args( $order_id );
-				$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
-			} catch ( Throwable $e ) {
-				$this->record_async_label_failure( $order_id, $e->getMessage() );
-
+			// Claim the order across processes so a concurrent job or a racing retry cannot also buy a label.
+			if ( ! $this->claim_order_label_lock( $order_id ) ) {
 				return;
 			}
 
-			// Purchase the label. Still safe to retry if this throws — nothing was bought.
 			try {
-				$label_tracking_info = PR_DHL()->get_dhl_factory()->get_dhl_label( $args );
-			} catch ( Throwable $e ) {
-				$this->record_async_label_failure( $order_id, $e->getMessage() );
+				// Re-check inside the claim: the holder may have created the label between our checks.
+				if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
+					$this->set_label_job_status( $order_id, self::JOB_CREATED );
 
-				return;
-			}
+					return;
+				}
 
-			// The label is now bought at DHL. A storage failure past this point must NOT be blindly
-			// retried (that would buy a second label), so flag it purchased — matching the batch path.
-			try {
-				$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
-				do_action( 'pr_shipping_dhl_label_created', $order_id );
-				$this->set_label_job_status(
-					$order_id,
-					self::JOB_CREATED,
-					array(
-						'warnings' => isset( $label_tracking_info['dhl_label_warnings'] ) ? $label_tracking_info['dhl_label_warnings'] : array(),
-					)
-				);
-			} catch ( Throwable $e ) {
-				$this->record_async_label_failure(
-					$order_id,
-					sprintf(
-						/* translators: %s is the storage error message */
-						esc_html__( 'DHL created the label but it could not be saved (%s). A label may already exist at DHL — verify before retrying.', 'dhl-for-woocommerce' ),
-						$e->getMessage()
-					),
-					array( 'purchased' => true )
-				);
+				// Build the request. A failure here is before any purchase, so the order is safe to retry.
+				try {
+					$this->save_default_dhl_label_items( $order_id );
+					$args = $this->get_label_args( $order_id );
+					$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
+				} catch ( Throwable $e ) {
+					$this->record_async_label_failure( $order_id, $e->getMessage() );
+
+					return;
+				}
+
+				// Purchase the label. Still safe to retry if this throws — nothing was bought.
+				try {
+					$label_tracking_info = PR_DHL()->get_dhl_factory()->get_dhl_label( $args );
+				} catch ( Throwable $e ) {
+					$this->record_async_label_failure( $order_id, $e->getMessage() );
+
+					return;
+				}
+
+				// The label is now bought at DHL. A storage failure past this point must NOT be blindly
+				// retried (that would buy a second label), so flag it purchased — matching the batch path.
+				try {
+					$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
+					do_action( 'pr_shipping_dhl_label_created', $order_id );
+					$this->set_label_job_status(
+						$order_id,
+						self::JOB_CREATED,
+						array(
+							'warnings' => isset( $label_tracking_info['dhl_label_warnings'] ) ? $label_tracking_info['dhl_label_warnings'] : array(),
+						)
+					);
+				} catch ( Throwable $e ) {
+					$this->record_async_label_failure(
+						$order_id,
+						sprintf(
+							/* translators: %s is the storage error message */
+							esc_html__( 'DHL created the label but it could not be saved (%s). A label may already exist at DHL — verify before retrying.', 'dhl-for-woocommerce' ),
+							$e->getMessage()
+						),
+						array( 'purchased' => true )
+					);
+				}
+			} finally {
+				$this->release_order_label_lock( $order_id );
 			}
 		}
 
@@ -682,9 +762,23 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			$batch_args = array();
+			$locked     = array();
 
 			foreach ( (array) $order_ids as $order_id ) {
 				// Idempotency: never recreate a label that already exists (covers job retries).
+				if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
+					$this->set_label_job_status( $order_id, self::JOB_CREATED );
+					continue;
+				}
+
+				// Claim the order across processes so a concurrent chunk (or a racing retry) cannot also
+				// purchase a label for it. If another process holds the claim, leave the order to them.
+				if ( ! $this->claim_order_label_lock( $order_id ) ) {
+					continue;
+				}
+				$locked[] = $order_id;
+
+				// Re-check inside the claim: the holder may have created the label between our checks.
 				if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
 					$this->set_label_job_status( $order_id, self::JOB_CREATED );
 					continue;
@@ -715,6 +809,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			if ( empty( $batch_args ) ) {
+				$this->release_order_label_locks( $locked );
+
 				return;
 			}
 
@@ -724,6 +820,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				foreach ( array_keys( $batch_args ) as $order_id ) {
 					$this->record_async_label_failure( $order_id, $e->getMessage() );
 				}
+
+				$this->release_order_label_locks( $locked );
 
 				return;
 			}
@@ -775,6 +873,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					$this->record_async_label_failure( $order_id, esc_html__( 'DHL did not return a label for this order.', 'dhl-for-woocommerce' ) );
 				}
 			}
+
+			$this->release_order_label_locks( $locked );
 		}
 
 		/**
@@ -2054,19 +2154,21 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		}
 
 		/**
-		 * Transient key holding the current user's in-flight bulk-label batch (the set of order IDs the
-		 * Orders-screen progress UI polls). Keyed per user so concurrent admins don't see each other's runs.
+		 * User-meta key holding the current user's in-flight bulk-label batch. Stored in durable user meta
+		 * (not a transient) so an object-cache eviction mid-run can't orphan the progress UI while jobs
+		 * that bought labels are still running.
 		 *
 		 * @return string
 		 */
-		protected function label_batch_key() {
-			return 'pr_dhl_label_batch_' . get_current_user_id();
+		protected function label_batch_meta_key() {
+			return '_pr_dhl_label_batch';
 		}
 
 		/**
-		 * Starts, or extends, the current user's tracked bulk-label batch. Order IDs from a batch that is
-		 * still running are merged in, so queuing a second selection before the first finishes keeps both
-		 * visible in the same progress bar rather than losing the earlier one.
+		 * Starts, or extends, the current user's tracked bulk-label batch. Orders from a previous batch
+		 * that are still pending or failed are carried over — so re-running before dismissing keeps both
+		 * the in-flight work and any earlier failures visible to Retry/Download — but already-created
+		 * orders are not (that would re-count them and re-merge their PDFs on "Download all").
 		 *
 		 * @param array $order_ids Order IDs just queued.
 		 *
@@ -2075,29 +2177,41 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		protected function start_label_batch( $order_ids ) {
 			$order_ids = array_map( 'intval', (array) $order_ids );
 
-			// Carry over only orders from a previous batch that are still in flight. A batch left
-			// undismissed after it finished must not bleed its already-created orders into this run
-			// (which would re-count them and re-merge their PDFs on "Download all").
 			$existing = $this->get_label_batch();
 			if ( ! empty( $existing['ids'] ) ) {
 				foreach ( $existing['ids'] as $existing_id ) {
-					if ( self::JOB_PENDING === $this->get_label_job_status( $existing_id )['status'] ) {
+					if ( ! empty( $this->get_dhl_label_tracking( $existing_id ) ) ) {
+						continue;
+					}
+
+					$status = $this->get_label_job_status( $existing_id )['status'];
+					if ( self::JOB_PENDING === $status || self::JOB_FAILED === $status ) {
 						$order_ids[] = $existing_id;
 					}
 				}
 				$order_ids = array_values( array_unique( $order_ids ) );
 			}
 
-			set_transient( $this->label_batch_key(), array( 'ids' => $order_ids, 'ts' => time() ), DAY_IN_SECONDS );
+			$now = time();
+			update_user_meta(
+				get_current_user_id(),
+				$this->label_batch_meta_key(),
+				array(
+					'ids'           => $order_ids,
+					'ts'            => $now,
+					'progress_ts'   => $now,
+					'progress_done' => 0,
+				)
+			);
 		}
 
 		/**
 		 * Returns the current user's tracked bulk-label batch.
 		 *
-		 * @return array Empty array when none is tracked, otherwise array{ids: int[]}.
+		 * @return array Empty array when none is tracked, otherwise array{ids: int[], ts: int, ...}.
 		 */
 		protected function get_label_batch() {
-			$batch = get_transient( $this->label_batch_key() );
+			$batch = get_user_meta( get_current_user_id(), $this->label_batch_meta_key(), true );
 
 			if ( ! is_array( $batch ) || empty( $batch['ids'] ) ) {
 				return array();
@@ -2114,7 +2228,28 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 * @return void
 		 */
 		protected function clear_label_batch() {
-			delete_transient( $this->label_batch_key() );
+			delete_user_meta( get_current_user_id(), $this->label_batch_meta_key() );
+		}
+
+		/**
+		 * Records the "last time progress advanced" snapshot used by the stall detector.
+		 *
+		 * @param int $settled created + failed count at this poll.
+		 * @param int $now      Current timestamp.
+		 *
+		 * @return void
+		 */
+		protected function update_label_batch_progress_snapshot( $settled, $now ) {
+			$batch = $this->get_label_batch();
+
+			if ( empty( $batch['ids'] ) ) {
+				return;
+			}
+
+			$batch['progress_done'] = (int) $settled;
+			$batch['progress_ts']   = (int) $now;
+
+			update_user_meta( get_current_user_id(), $this->label_batch_meta_key(), $batch );
 		}
 
 		/**
@@ -2129,22 +2264,54 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				return null;
 			}
 
+			$ids = $batch['ids'];
+
+			// Load the whole set in one query so a large batch is not N separate order loads per 5s poll.
+			$by_id = array();
+			foreach ( wc_get_orders( array( 'limit' => -1, 'include' => $ids ) ) as $order ) {
+				$by_id[ $order->get_id() ] = $order;
+			}
+
 			$created   = 0;
 			$failed    = 0;
 			$pending   = 0;
 			$purchased = 0;
 			$failures  = array();
 
-			// The background callbacks always record a terminal JOB_CREATED / JOB_FAILED for every queued
-			// order, so the stored job status is authoritative here — no need for a second per-order load
-			// of the label tracking meta.
-			foreach ( $batch['ids'] as $order_id ) {
-				$job    = $this->get_label_job_status( $order_id );
-				$status = $job['status'];
+			foreach ( $ids as $order_id ) {
+				$order = isset( $by_id[ $order_id ] ) ? $by_id[ $order_id ] : null;
 
-				if ( self::JOB_CREATED === $status ) {
+				// An order deleted after it was queued counts as failed, so the batch can still complete.
+				if ( ! $order instanceof WC_Order ) {
+					++$failed;
+					if ( count( $failures ) < 100 ) {
+						$failures[] = array(
+							'order_id'  => $order_id,
+							'number'    => (string) $order_id,
+							'message'   => __( 'The order no longer exists.', 'dhl-for-woocommerce' ),
+							'purchased' => false,
+							'edit_url'  => '',
+						);
+					}
+					continue;
+				}
+
+				if ( ! empty( $order->get_meta( '_pr_shipment_dhl_label_tracking' ) ) ) {
 					++$created;
-				} elseif ( self::JOB_FAILED === $status ) {
+					continue;
+				}
+
+				$raw = $order->get_meta( self::JOB_STATUS_META );
+				$job = wp_parse_args(
+					is_array( $raw ) ? $raw : array(),
+					array(
+						'status'    => '',
+						'message'   => '',
+						'purchased' => false,
+					)
+				);
+
+				if ( self::JOB_FAILED === $job['status'] ) {
 					++$failed;
 
 					// A label bought at DHL but not saved locally must not be retried (it would double-buy);
@@ -2153,13 +2320,11 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						++$purchased;
 					}
 
-					// Cap the detail list so a huge failing batch cannot bloat the polled payload; the
-					// counts above still cover every order.
+					// Cap the detail list so a huge failing batch cannot bloat the polled payload.
 					if ( count( $failures ) < 100 ) {
-						$order      = wc_get_order( $order_id );
 						$failures[] = array(
 							'order_id'  => $order_id,
-							'number'    => $order ? (string) $order->get_order_number() : (string) $order_id,
+							'number'    => (string) $order->get_order_number(),
 							'message'   => '' !== $job['message'] ? $job['message'] : __( 'DHL label creation failed.', 'dhl-for-woocommerce' ),
 							'purchased' => ! empty( $job['purchased'] ),
 							'edit_url'  => $this->get_order_edit_url( $order_id ),
@@ -2170,19 +2335,26 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				}
 			}
 
-			$done       = 0 === $pending;
-			$started_at = isset( $batch['ts'] ) ? (int) $batch['ts'] : 0;
+			$done    = 0 === $pending;
+			$settled = $created + $failed;
+			$now     = time();
 
-			// If a grace period passes with nothing processed at all, the Action Scheduler queue is
-			// almost certainly not running (no cron / no queue runner). Surface that instead of spinning
-			// forever, so the merchant can act rather than wait indefinitely.
-			$stalled = ! $done
-				&& 0 === ( $created + $failed )
-				&& $started_at > 0
-				&& ( time() - $started_at ) > 120;
+			// Stall detection measures time since progress last advanced (a sliding window), not wall-clock
+			// since start. This avoids false alarms on a busy Action Scheduler backlog, and still catches a
+			// queue runner that dies part-way through (progress freezes, so the window elapses).
+			$progress_ts   = isset( $batch['progress_ts'] ) ? (int) $batch['progress_ts'] : ( isset( $batch['ts'] ) ? (int) $batch['ts'] : $now );
+			$progress_done = isset( $batch['progress_done'] ) ? (int) $batch['progress_done'] : 0;
+
+			if ( $settled > $progress_done ) {
+				$progress_ts = $now;
+				$this->update_label_batch_progress_snapshot( $settled, $now );
+			}
+
+			$threshold = (int) apply_filters( 'pr_dhl_label_batch_stall_seconds', 180 );
+			$stalled   = ! $done && $pending > 0 && ( $now - $progress_ts ) > $threshold;
 
 			return array(
-				'total'        => count( $batch['ids'] ),
+				'total'        => count( $ids ),
 				'created'      => $created,
 				'failed'       => $failed,
 				'pending'      => $pending,

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -1268,9 +1268,10 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							array_push( $merge_files, PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] ) );
 						}
 					} catch ( Exception $e ) {
+						$order_number = $order ? $order->get_order_number() : $order_id;
 						$array_messages[] = array(
 							/* translators: %1$s is the order number, %2$s is the error message */
-							'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order->get_order_number() ), $e->getMessage() ),
+							'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order_number ), $e->getMessage() ),
 							'type'    => 'error',
 						);
 					}
@@ -1278,6 +1279,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 				// Create every deferred order in one API request, then map the results back per order.
 				if ( $use_batch && ! empty( $batch_args ) ) {
+					$handled_orders = array();
+
 					try {
 						$labels_result = $dhl_obj->get_dhl_labels( array_values( $batch_args ) );
 					} catch ( Exception $e ) {
@@ -1289,11 +1292,13 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						// A failure of the whole request applies to every queued order.
 						foreach ( array_keys( $batch_args ) as $failed_order_id ) {
 							$failed_order     = wc_get_order( $failed_order_id );
+							$order_number     = $failed_order ? $failed_order->get_order_number() : $failed_order_id;
 							$array_messages[] = array(
 								/* translators: %1$s is the order number, %2$s is the error message */
-								'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $failed_order->get_order_number() ), $e->getMessage() ),
+								'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order_number ), $e->getMessage() ),
 								'type'    => 'error',
 							);
+							$handled_orders[ $failed_order_id ] = true;
 						}
 					}
 
@@ -1304,6 +1309,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						if ( ! empty( $label_tracking_info['label_path'] ) ) {
 							array_push( $merge_files, PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] ) );
 						}
+
+						$handled_orders[ $label_tracking_info['order_id'] ] = true;
 					}
 
 					foreach ( $labels_result['errors'] as $error ) {
@@ -1314,6 +1321,23 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							'message' => wp_kses_post( sprintf( __( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), $order_number, $error['message'] ) ),
 							'type'    => 'error',
 						);
+
+						if ( ! empty( $error['order_id'] ) ) {
+							$handled_orders[ $error['order_id'] ] = true;
+						}
+					}
+
+					// Surface any queued order the API neither created nor reported, so nothing fails silently.
+					foreach ( array_keys( $batch_args ) as $order_id ) {
+						if ( empty( $handled_orders[ $order_id ] ) ) {
+							$order            = wc_get_order( $order_id );
+							$order_number     = $order ? $order->get_order_number() : $order_id;
+							$array_messages[] = array(
+								/* translators: %s is the order number */
+								'message' => sprintf( esc_html__( 'Order #%s: DHL label could not be created.', 'dhl-for-woocommerce' ), esc_html( $order_number ) ),
+								'type'    => 'error',
+							);
+						}
 					}
 				}
 				try {
@@ -1368,18 +1392,23 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		protected function save_created_dhl_label( $order_id, $label_tracking_info ) {
 			$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
 
-			$order              = wc_get_order( $order_id );
-			$tracking_note      = $this->get_tracking_note( $order_id );
-			$tracking_note_type = $this->get_tracking_note_type();
-			$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
+			$order = wc_get_order( $order_id );
 
-			$order->add_order_note( $tracking_note, $tracking_note_type, true );
+			if ( $order ) {
+				$tracking_note      = $this->get_tracking_note( $order_id );
+				$tracking_note_type = $this->get_tracking_note_type();
+				$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
+
+				$order->add_order_note( $tracking_note, $tracking_note_type, true );
+			}
 
 			do_action( 'pr_shipping_dhl_label_created', $order_id );
 
+			$order_number = $order ? $order->get_order_number() : $order_id;
+
 			return array(
 				/* translators: %s is the order number */
-				'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
+				'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order_number ),
 				'type'    => 'success',
 			);
 		}

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -364,18 +364,11 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				// Gather args for DHL API call
 				$args = $this->get_label_args( $order_id );
 
-				// Allow third parties to modify the args to the DHL APIs
-				$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
+				$this->create_dhl_label( $order_id, $args );
 
-				$dhl_obj             = PR_DHL()->get_dhl_factory();
-				$label_tracking_info = $dhl_obj->get_dhl_label( $args );
-
-				$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
 				$tracking_note      = $this->get_tracking_note( $order_id );
 				$tracking_note_type = $this->get_tracking_note_type();
 				$label_url          = $this->get_download_label_url( $order_id );
-
-				do_action( 'pr_shipping_dhl_label_created', $order_id );
 
 				wp_send_json(
 					array(
@@ -394,6 +387,33 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			wp_die();
+		}
+
+		/**
+		 * Creates a DHL label for a single order and persists its tracking data.
+		 *
+		 * Shared by the single-order and bulk label flows: applies the label-args
+		 * filter, calls the DHL API, saves the returned tracking data and fires the
+		 * label-created hook.
+		 *
+		 * @param int   $order_id Order ID.
+		 * @param array $args     Label args already gathered via get_label_args().
+		 *
+		 * @return array The label tracking info returned by the DHL API.
+		 * @throws Exception If the DHL API fails to create the label.
+		 */
+		protected function create_dhl_label( $order_id, $args ) {
+			// Allow third parties to modify the args to the DHL APIs
+			$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
+
+			$dhl_obj             = PR_DHL()->get_dhl_factory();
+			$label_tracking_info = $dhl_obj->get_dhl_label( $args );
+
+			$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
+
+			do_action( 'pr_shipping_dhl_label_created', $order_id );
+
+			return $label_tracking_info;
 		}
 
 		public function delete_label_ajax() {
@@ -1215,8 +1235,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 			if ( 'pr_dhl_create_labels' === $action ) {
 
-				$dhl_obj = PR_DHL()->get_dhl_factory();
-
 				foreach ( $order_ids as $order_id ) {
 					$order = wc_get_order( $order_id );
 
@@ -1248,13 +1266,9 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							// Allow settings to override saved order data, ONLY for bulk action
 							$args = $this->get_bulk_settings_override( $args );
 
-							// Allow third parties to modify the args to the DHL APIs
-							$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
-
 							// API request.
-							$label_tracking_info = $dhl_obj->get_dhl_label( $args );
-							$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
-							$tracking_note = $this->get_tracking_note( $order_id );
+							$label_tracking_info = $this->create_dhl_label( $order_id, $args );
+							$tracking_note       = $this->get_tracking_note( $order_id );
 
 							$tracking_note_type = $this->get_tracking_note_type();
 							$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
@@ -1268,8 +1282,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 								'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
 								'type'    => 'success',
 							);
-
-							do_action( 'pr_shipping_dhl_label_created', $order_id );
 						}
 
 						if ( ! empty( $label_tracking_info['label_path'] ) ) {

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -213,6 +213,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 			echo '<div id="shipment-dhl-label-form">';
 
+			echo $this->get_label_job_status_notice( $order_id, $label_tracking_info );
+
 			if ( ! empty( $dhl_product_list ) ) {
 
 				woocommerce_wp_hidden_input(
@@ -571,6 +573,50 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		}
 
 		/**
+		 * Queues one background label-creation job per order, for APIs without a batch endpoint
+		 * (e.g. Deutsche Post). Orders that already have a label or a job in flight are skipped so
+		 * re-running the bulk action cannot enqueue a duplicate job for the same order.
+		 *
+		 * @param array $order_ids Selected order IDs.
+		 *
+		 * @return array Bulk-action feedback messages.
+		 */
+		protected function enqueue_per_order_label_jobs( $order_ids ) {
+			$pending_orders = array();
+			foreach ( $order_ids as $order_id ) {
+				if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
+					continue;
+				}
+
+				if ( ! $this->schedule_label_creation( $order_id ) ) {
+					continue;
+				}
+
+				$pending_orders[] = $order_id;
+			}
+
+			if ( empty( $pending_orders ) ) {
+				return array(
+					array(
+						'message' => esc_html__( 'The selected orders already have DHL labels.', 'dhl-for-woocommerce' ),
+						'type'    => 'warning',
+					),
+				);
+			}
+
+			return array(
+				array(
+					'message' => sprintf(
+						/* translators: %d is the number of orders queued */
+						esc_html( _n( '%d order queued for background DHL label creation.', '%d orders queued for background DHL label creation.', count( $pending_orders ), 'dhl-for-woocommerce' ) ),
+						count( $pending_orders )
+					),
+					'type'    => 'success',
+				),
+			);
+		}
+
+		/**
 		 * Action Scheduler callback: create labels for a chunk of orders in one batched request.
 		 *
 		 * Orders that already have a label are skipped before the request is built, so a retried
@@ -762,6 +808,50 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			return wp_parse_args( $status, $default );
+		}
+
+		/**
+		 * Renders the background label job state for the order metabox: a "being created" notice while a
+		 * job is pending and the failure reason when the last job failed. Returns an empty string once a
+		 * label exists (the download button already makes that state obvious) or when no job has run.
+		 *
+		 * @param int        $order_id            Order ID.
+		 * @param array|null $label_tracking_info Already-loaded tracking info, to avoid a second lookup.
+		 *
+		 * @return string HTML markup, or an empty string when there is nothing to show.
+		 */
+		protected function get_label_job_status_notice( $order_id, $label_tracking_info = null ) {
+			if ( null === $label_tracking_info ) {
+				$label_tracking_info = $this->get_dhl_label_tracking( $order_id );
+			}
+
+			if ( ! empty( $label_tracking_info ) ) {
+				return '';
+			}
+
+			$job = $this->get_label_job_status( $order_id );
+
+			if ( self::JOB_PENDING === $job['status'] ) {
+				return '<p class="wc_dhl_label_job wc_dhl_label_job--pending">'
+					. esc_html__( 'A DHL label is being created for this order in the background. Reload the page to see the result.', 'dhl-for-woocommerce' )
+					. '</p>';
+			}
+
+			if ( self::JOB_FAILED === $job['status'] ) {
+				$message = '' !== $job['message']
+					? $job['message']
+					: esc_html__( 'The DHL label could not be created.', 'dhl-for-woocommerce' );
+
+				return '<p class="wc_dhl_error wc_dhl_label_job wc_dhl_label_job--failed">'
+					. sprintf(
+						/* translators: %s is the failure reason returned by DHL */
+						esc_html__( 'Background DHL label creation failed: %s', 'dhl-for-woocommerce' ),
+						esc_html( $message )
+					)
+					. '</p>';
+			}
+
+			return '';
 		}
 
 		public function delete_label_ajax() {
@@ -1587,9 +1677,13 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				// APIs exposing get_dhl_labels() create every selected order in a single request.
 				$use_batch = method_exists( $dhl_obj, 'get_dhl_labels' );
 
-				// Move bulk creation into background jobs when batching and Action Scheduler are both available.
-				if ( $use_batch && $this->is_action_scheduler_available() ) {
-					return $this->enqueue_bulk_label_jobs( $order_ids, $dhl_force_product, $is_force_product_dom );
+				// Move bulk creation into background jobs whenever Action Scheduler is available. Batch-capable
+				// APIs (DHL Paket) are chunked into batched requests; the rest (Deutsche Post, which has no batch
+				// endpoint) run one background job per order. Either way the work leaves the user-facing request.
+				if ( $this->is_action_scheduler_available() ) {
+					return $use_batch
+						? $this->enqueue_bulk_label_jobs( $order_ids, $dhl_force_product, $is_force_product_dom )
+						: $this->enqueue_per_order_label_jobs( $order_ids );
 				}
 
 				$batch_args = array();
@@ -1747,11 +1841,115 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						'type'    => 'error',
 					);
 				}
+			} elseif ( 'pr_dhl_retry_failed_labels' === $action ) {
+				$array_messages = $this->retry_failed_label_jobs( $order_ids );
+			} elseif ( 'pr_dhl_download_labels' === $action ) {
+				$array_messages = $this->build_bulk_label_download( $order_ids );
 			} elseif ( 'pr_dhl_delete_labels' === $action ) {
 				$array_messages = $this->delete_label_in_bulk( $order_ids );
 			}
 
 			return $array_messages;
+		}
+
+		/**
+		 * Re-queues background label creation for the selected orders whose last job failed. Orders that
+		 * already have a label or never ran a job are left untouched, so the action only ever retries
+		 * genuine failures. Retried orders flow through the same background path as the initial run.
+		 *
+		 * @param array $order_ids Selected order IDs.
+		 *
+		 * @return array Bulk-action feedback messages.
+		 */
+		protected function retry_failed_label_jobs( $order_ids ) {
+			$failed_orders = array();
+
+			foreach ( $order_ids as $order_id ) {
+				if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
+					continue;
+				}
+
+				if ( self::JOB_FAILED === $this->get_label_job_status( $order_id )['status'] ) {
+					$failed_orders[] = $order_id;
+				}
+			}
+
+			if ( empty( $failed_orders ) ) {
+				return array(
+					array(
+						'message' => esc_html__( 'No failed DHL label jobs were found in the selected orders.', 'dhl-for-woocommerce' ),
+						'type'    => 'warning',
+					),
+				);
+			}
+
+			return $this->process_bulk_actions( 'pr_dhl_create_labels', $failed_orders );
+		}
+
+		/**
+		 * Builds a merged PDF of the labels already created for the selected orders and returns a
+		 * download link. This is how a completed background batch is downloaded in one file: the bulk
+		 * request no longer produces the merged PDF itself, so the labels are gathered from storage here.
+		 *
+		 * @param array $order_ids Selected order IDs.
+		 *
+		 * @return array Bulk-action feedback messages.
+		 */
+		protected function build_bulk_label_download( $order_ids ) {
+			$merge_files = array();
+
+			foreach ( $order_ids as $order_id ) {
+				$label_tracking_info = $this->get_dhl_label_tracking( $order_id );
+
+				if ( ! empty( $label_tracking_info['label_path'] ) ) {
+					$merge_files[] = PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] );
+				}
+			}
+
+			if ( empty( $merge_files ) ) {
+				return array(
+					array(
+						'message' => esc_html__( 'None of the selected orders have a DHL label to download yet.', 'dhl-for-woocommerce' ),
+						'type'    => 'warning',
+					),
+				);
+			}
+
+			try {
+				$file_bulk = $this->merge_label_files( $merge_files );
+
+				if ( ! file_exists( $file_bulk['file_bulk_path'] ) ) {
+					return array(
+						array(
+							'message' => esc_html__( 'Could not create bulk DHL label file, download individually.', 'dhl-for-woocommerce' ),
+							'type'    => 'error',
+						),
+					);
+				}
+
+				set_transient(
+					'_dhl_bulk_download_labels_file_' . get_current_user_id(),
+					$file_bulk['file_bulk_path'],
+					180
+				);
+
+				$bulk_download_label_url = $this->generate_download_url( '/' . self::DHL_DOWNLOAD_ENDPOINT . '/bulk' );
+
+				return array(
+					array(
+						/* translators: %1$s and %2$s are the opening and closing tags of the download link */
+						'message' => wp_kses_post( sprintf( __( 'Bulk DHL labels file created - %1$sdownload file%2$s', 'dhl-for-woocommerce' ), '<a href="' . esc_url( $bulk_download_label_url ) . '" download>', '</a>' ) ),
+						'type'    => 'success',
+					),
+				);
+			} catch ( Exception $e ) {
+				return array(
+					array(
+						'message' => wp_kses_post( $e->getMessage() ),
+						'type'    => 'error',
+					),
+				);
+			}
 		}
 
 		/**

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -519,12 +519,20 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 * @return array Bulk-action feedback messages.
 		 */
 		protected function enqueue_bulk_label_jobs( $order_ids, $dhl_force_product = false, $is_force_product_dom = false ) {
-			// Only queue orders that do not already have a label.
+			// Queue only orders that have no label yet and no job already in flight, so re-running
+			// the bulk action (or a double-click) cannot enqueue a second job for the same order.
 			$pending_orders = array();
 			foreach ( $order_ids as $order_id ) {
-				if ( empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
-					$pending_orders[] = $order_id;
+				if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
+					continue;
 				}
+
+				$job = $this->get_label_job_status( $order_id );
+				if ( self::JOB_PENDING === $job['status'] ) {
+					continue;
+				}
+
+				$pending_orders[] = $order_id;
 			}
 
 			if ( empty( $pending_orders ) ) {

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -2076,20 +2076,42 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				return null;
 			}
 
-			$created = 0;
-			$failed  = 0;
-			$pending = 0;
+			$created   = 0;
+			$failed    = 0;
+			$pending   = 0;
+			$purchased = 0;
+			$failures  = array();
 
 			// The background callbacks always record a terminal JOB_CREATED / JOB_FAILED for every queued
 			// order, so the stored job status is authoritative here — no need for a second per-order load
 			// of the label tracking meta.
 			foreach ( $batch['ids'] as $order_id ) {
-				$status = $this->get_label_job_status( $order_id )['status'];
+				$job    = $this->get_label_job_status( $order_id );
+				$status = $job['status'];
 
 				if ( self::JOB_CREATED === $status ) {
 					++$created;
 				} elseif ( self::JOB_FAILED === $status ) {
 					++$failed;
+
+					// A label bought at DHL but not saved locally must not be retried (it would double-buy);
+					// it is surfaced separately so the merchant can verify it by hand.
+					if ( ! empty( $job['purchased'] ) ) {
+						++$purchased;
+					}
+
+					// Cap the detail list so a huge failing batch cannot bloat the polled payload; the
+					// counts above still cover every order.
+					if ( count( $failures ) < 100 ) {
+						$order      = wc_get_order( $order_id );
+						$failures[] = array(
+							'order_id'  => $order_id,
+							'number'    => $order ? (string) $order->get_order_number() : (string) $order_id,
+							'message'   => '' !== $job['message'] ? $job['message'] : __( 'DHL label creation failed.', 'dhl-for-woocommerce' ),
+							'purchased' => ! empty( $job['purchased'] ),
+							'edit_url'  => $this->get_order_edit_url( $order_id ),
+						);
+					}
 				} else {
 					++$pending;
 				}
@@ -2111,11 +2133,29 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				'created'      => $created,
 				'failed'       => $failed,
 				'pending'      => $pending,
+				'purchased'    => $purchased,
 				'done'         => $done,
 				'stalled'      => $stalled,
 				'has_failed'   => $failed > 0,
+				'retryable'    => ( $failed - $purchased ) > 0,
 				'can_download' => $created > 0,
+				'failures'     => $failures,
 			);
+		}
+
+		/**
+		 * Admin edit-screen URL for an order, on both HPOS and the legacy post table.
+		 *
+		 * @param int $order_id Order ID.
+		 *
+		 * @return string
+		 */
+		protected function get_order_edit_url( $order_id ) {
+			if ( API_Utils::is_HPOS() ) {
+				return admin_url( 'admin.php?page=wc-orders&action=edit&id=' . absint( $order_id ) );
+			}
+
+			return admin_url( 'post.php?post=' . absint( $order_id ) . '&action=edit' );
 		}
 
 		/**
@@ -2248,6 +2288,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						'doneOk'     => esc_html__( 'All DHL labels created.', 'dhl-for-woocommerce' ),
 						'doneErrors' => esc_html__( 'DHL label creation finished — some orders failed.', 'dhl-for-woocommerce' ),
 						'stalled'    => esc_html__( 'DHL labels are still queued but nothing is processing yet — your site may not be running background tasks. Check WooCommerce → Status → Scheduled Actions, or reload later.', 'dhl-for-woocommerce' ),
+						'failTitle'  => esc_html__( 'Orders that could not be created:', 'dhl-for-woocommerce' ),
+						'purchased'  => esc_html__( 'Some orders may already have a label at DHL — open them and verify before retrying. Retry does not re-create these.', 'dhl-for-woocommerce' ),
 						'error'      => esc_html__( 'Something went wrong. Please reload the page.', 'dhl-for-woocommerce' ),
 					),
 				)
@@ -2269,6 +2311,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				<p class="pr-dhl-label-batch__title"><strong></strong></p>
 				<div class="pr-dhl-label-batch__bar"><span class="pr-dhl-label-batch__fill"></span></div>
 				<p class="pr-dhl-label-batch__status"></p>
+				<div class="pr-dhl-label-batch__details"></div>
 				<p class="pr-dhl-label-batch__actions" style="display:none;">
 					<a href="#" class="button button-primary pr-dhl-label-batch__download"><?php echo esc_html__( 'Download all labels', 'dhl-for-woocommerce' ); ?></a>
 					<a href="#" class="button pr-dhl-label-batch__retry"><?php echo esc_html__( 'Retry failed', 'dhl-for-woocommerce' ); ?></a>

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -1211,11 +1211,14 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			$label_count    = 0;
 			$merge_files    = array();
 			$array_messages = array();
-			$orders_args    = array();
 
 			if ( 'pr_dhl_create_labels' === $action ) {
 
 				$dhl_obj = PR_DHL()->get_dhl_factory();
+
+				// APIs exposing get_dhl_labels() create every selected order in a single request.
+				$use_batch  = method_exists( $dhl_obj, 'get_dhl_labels' );
+				$batch_args = array();
 
 				foreach ( $order_ids as $order_id ) {
 					$order = wc_get_order( $order_id );
@@ -1225,8 +1228,6 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						if ( empty( $label_tracking_info = $this->get_dhl_label_tracking( $order_id ) ) ) {
 
 							$this->save_default_dhl_label_items( $order_id );
-
-							// $dhl_label_items = $this->get_dhl_label_items( $order_id );
 
 							// Gather args for DHL API call
 							$args = $this->get_label_args( $order_id );
@@ -1251,25 +1252,16 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							// Allow third parties to modify the args to the DHL APIs
 							$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
 
+							// Defer to a single batched request when the API supports it.
+							if ( $use_batch ) {
+								$batch_args[ $order_id ] = $args;
+								continue;
+							}
+
 							// API request.
 							$label_tracking_info = $dhl_obj->get_dhl_label( $args );
-							$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
-							$tracking_note = $this->get_tracking_note( $order_id );
-
-							$tracking_note_type = $this->get_tracking_note_type();
-							$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
-
-							$order->add_order_note( $tracking_note, $tracking_note_type, true );
-
+							$array_messages[]    = $this->save_created_dhl_label( $order_id, $label_tracking_info );
 							++$label_count;
-
-							$array_messages[] = array(
-								/* translators: %s is the order number */
-								'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
-								'type'    => 'success',
-							);
-
-							do_action( 'pr_shipping_dhl_label_created', $order_id );
 						}
 
 						if ( ! empty( $label_tracking_info['label_path'] ) ) {
@@ -1279,6 +1271,47 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						$array_messages[] = array(
 							/* translators: %1$s is the order number, %2$s is the error message */
 							'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $order->get_order_number() ), $e->getMessage() ),
+							'type'    => 'error',
+						);
+					}
+				}
+
+				// Create every deferred order in one API request, then map the results back per order.
+				if ( $use_batch && ! empty( $batch_args ) ) {
+					try {
+						$labels_result = $dhl_obj->get_dhl_labels( array_values( $batch_args ) );
+					} catch ( Exception $e ) {
+						$labels_result = array(
+							'labels' => array(),
+							'errors' => array(),
+						);
+
+						// A failure of the whole request applies to every queued order.
+						foreach ( array_keys( $batch_args ) as $failed_order_id ) {
+							$failed_order     = wc_get_order( $failed_order_id );
+							$array_messages[] = array(
+								/* translators: %1$s is the order number, %2$s is the error message */
+								'message' => sprintf( esc_html__( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), esc_html( $failed_order->get_order_number() ), $e->getMessage() ),
+								'type'    => 'error',
+							);
+						}
+					}
+
+					foreach ( $labels_result['labels'] as $label_tracking_info ) {
+						$array_messages[] = $this->save_created_dhl_label( $label_tracking_info['order_id'], $label_tracking_info );
+						++$label_count;
+
+						if ( ! empty( $label_tracking_info['label_path'] ) ) {
+							array_push( $merge_files, PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] ) );
+						}
+					}
+
+					foreach ( $labels_result['errors'] as $error ) {
+						$failed_order = wc_get_order( $error['order_id'] );
+						$order_number = $failed_order ? $failed_order->get_order_number() : $error['order_id'];
+						$array_messages[] = array(
+							/* translators: %1$s is the order number, %2$s is the error message */
+							'message' => wp_kses_post( sprintf( __( 'Order #%1$s: %2$s', 'dhl-for-woocommerce' ), $order_number, $error['message'] ) ),
 							'type'    => 'error',
 						);
 					}
@@ -1321,6 +1354,34 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			}
 
 			return $array_messages;
+		}
+
+		/**
+		 * Persist a freshly created DHL label: store its tracking data, add the order note
+		 * and fire the label-created action.
+		 *
+		 * @param int   $order_id            The WooCommerce order ID.
+		 * @param array $label_tracking_info The tracking data returned by the DHL API.
+		 *
+		 * @return array The success message entry for the bulk action feedback.
+		 */
+		protected function save_created_dhl_label( $order_id, $label_tracking_info ) {
+			$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
+
+			$order              = wc_get_order( $order_id );
+			$tracking_note      = $this->get_tracking_note( $order_id );
+			$tracking_note_type = $this->get_tracking_note_type();
+			$tracking_note_type = empty( $tracking_note_type ) ? 0 : 1;
+
+			$order->add_order_note( $tracking_note, $tracking_note_type, true );
+
+			do_action( 'pr_shipping_dhl_label_created', $order_id );
+
+			return array(
+				/* translators: %s is the order number */
+				'message' => sprintf( esc_html__( 'Order #%s: DHL label created', 'dhl-for-woocommerce' ), $order->get_order_number() ),
+				'type'    => 'success',
+			);
 		}
 
 		/**

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -499,13 +499,39 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				return;
 			}
 
+			// An order deleted between queuing and running would otherwise fatal deep in get_label_args();
+			// record it and move on instead.
+			if ( ! wc_get_order( $order_id ) instanceof WC_Order ) {
+				$this->set_label_job_status( $order_id, self::JOB_FAILED, array( 'message' => esc_html__( 'The order no longer exists.', 'dhl-for-woocommerce' ) ) );
+
+				return;
+			}
+
+			// Build the request. A failure here is before any purchase, so the order is safe to retry.
 			try {
 				$this->save_default_dhl_label_items( $order_id );
-
 				$args = $this->get_label_args( $order_id );
+				$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
+			} catch ( Throwable $e ) {
+				$this->record_async_label_failure( $order_id, $e->getMessage() );
 
-				$label_tracking_info = $this->create_dhl_label( $order_id, $args );
+				return;
+			}
 
+			// Purchase the label. Still safe to retry if this throws — nothing was bought.
+			try {
+				$label_tracking_info = PR_DHL()->get_dhl_factory()->get_dhl_label( $args );
+			} catch ( Throwable $e ) {
+				$this->record_async_label_failure( $order_id, $e->getMessage() );
+
+				return;
+			}
+
+			// The label is now bought at DHL. A storage failure past this point must NOT be blindly
+			// retried (that would buy a second label), so flag it purchased — matching the batch path.
+			try {
+				$this->save_dhl_label_tracking( $order_id, $label_tracking_info );
+				do_action( 'pr_shipping_dhl_label_created', $order_id );
 				$this->set_label_job_status(
 					$order_id,
 					self::JOB_CREATED,
@@ -513,8 +539,16 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						'warnings' => isset( $label_tracking_info['dhl_label_warnings'] ) ? $label_tracking_info['dhl_label_warnings'] : array(),
 					)
 				);
-			} catch ( Exception $e ) {
-				$this->record_async_label_failure( $order_id, $e->getMessage() );
+			} catch ( Throwable $e ) {
+				$this->record_async_label_failure(
+					$order_id,
+					sprintf(
+						/* translators: %s is the storage error message */
+						esc_html__( 'DHL created the label but it could not be saved (%s). A label may already exist at DHL — verify before retrying.', 'dhl-for-woocommerce' ),
+						$e->getMessage()
+					),
+					array( 'purchased' => true )
+				);
 			}
 		}
 
@@ -675,7 +709,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					$args = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
 
 					$batch_args[ $order_id ] = $args;
-				} catch ( Exception $e ) {
+				} catch ( Throwable $e ) {
 					$this->record_async_label_failure( $order_id, $e->getMessage() );
 				}
 			}
@@ -686,7 +720,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 			try {
 				$labels_result = $dhl_obj->get_dhl_labels( array_values( $batch_args ) );
-			} catch ( Exception $e ) {
+			} catch ( Throwable $e ) {
 				foreach ( array_keys( $batch_args ) as $order_id ) {
 					$this->record_async_label_failure( $order_id, $e->getMessage() );
 				}
@@ -711,7 +745,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							'warnings' => isset( $label_tracking_info['dhl_label_warnings'] ) ? $label_tracking_info['dhl_label_warnings'] : array(),
 						)
 					);
-				} catch ( Exception $e ) {
+				} catch ( Throwable $e ) {
 					// Flag the purchased-but-unsaved case distinctly so a later retry does not
 					// blindly buy a duplicate for a label that already exists at DHL.
 					$this->record_async_label_failure(

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -633,14 +633,30 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			foreach ( $labels_result['labels'] as $label_tracking_info ) {
 				$order_id = $label_tracking_info['order_id'];
 
-				$this->save_created_dhl_label( $order_id, $label_tracking_info );
-				$this->set_label_job_status(
-					$order_id,
-					self::JOB_CREATED,
-					array(
-						'warnings' => isset( $label_tracking_info['dhl_label_warnings'] ) ? $label_tracking_info['dhl_label_warnings'] : array(),
-					)
-				);
+				// The label has already been purchased at DHL. Persist it, but never let a storage
+				// failure escape this callback: an uncaught error would make Action Scheduler retry
+				// the whole chunk and buy a second label for every order that was not yet saved.
+				try {
+					$this->save_created_dhl_label( $order_id, $label_tracking_info );
+					$this->set_label_job_status(
+						$order_id,
+						self::JOB_CREATED,
+						array(
+							'warnings' => isset( $label_tracking_info['dhl_label_warnings'] ) ? $label_tracking_info['dhl_label_warnings'] : array(),
+						)
+					);
+				} catch ( Exception $e ) {
+					// Flag the purchased-but-unsaved case distinctly so a later retry does not
+					// blindly buy a duplicate for a label that already exists at DHL.
+					$this->record_async_label_failure(
+						$order_id,
+						sprintf(
+							/* translators: %s is the storage error message */
+							esc_html__( 'DHL created the label but it could not be saved (%s). A label may already exist at DHL — verify before retrying.', 'dhl-for-woocommerce' ),
+							$e->getMessage()
+						)
+					);
+				}
 
 				$handled[ $order_id ] = true;
 			}

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -886,13 +886,26 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 * @return string
 		 */
 		protected function humanize_label_error( $message ) {
-			// Connection-level failures (timeouts, DNS, refused, SSL) are almost always transient network
-			// issues rather than bad order data, so point the merchant at Retry instead of a raw cURL string.
-			if ( preg_match( '/cURL error (7|28|35|56)|timed out|timeout|could not resolve host|failed to connect|ssl connection/i', $message ) ) {
+			// Connection-level failures are almost always transient network issues rather than bad order
+			// data, so point the merchant at Retry instead of leaving them with a raw cURL string.
+			if ( $this->is_transient_label_error( $message ) ) {
 				return $message . ' ' . esc_html__( '(The DHL API could not be reached — usually a temporary network issue; use Retry.)', 'dhl-for-woocommerce' );
 			}
 
 			return $message;
+		}
+
+		/**
+		 * Whether a failure message looks like a transient connectivity problem (timeout, DNS, refused,
+		 * SSL) — i.e. a plain Retry will probably clear it — versus a data/validation error that needs the
+		 * order fixed first.
+		 *
+		 * @param string $message Failure message.
+		 *
+		 * @return bool
+		 */
+		protected function is_transient_label_error( $message ) {
+			return (bool) preg_match( '/cURL error (7|28|35|56)|timed out|timeout|could not resolve host|failed to connect|ssl connection/i', $message );
 		}
 
 		/**
@@ -2290,6 +2303,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 							'number'    => (string) $order_id,
 							'message'   => __( 'The order no longer exists.', 'dhl-for-woocommerce' ),
 							'purchased' => false,
+							'category'  => 'action',
 							'edit_url'  => '',
 						);
 					}
@@ -2322,11 +2336,22 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 					// Cap the detail list so a huge failing batch cannot bloat the polled payload.
 					if ( count( $failures ) < 100 ) {
+						$failure_message = '' !== $job['message'] ? $job['message'] : __( 'DHL label creation failed.', 'dhl-for-woocommerce' );
+
+						if ( ! empty( $job['purchased'] ) ) {
+							$category = 'purchased';
+						} elseif ( $this->is_transient_label_error( $failure_message ) ) {
+							$category = 'transient';
+						} else {
+							$category = 'action';
+						}
+
 						$failures[] = array(
 							'order_id'  => $order_id,
 							'number'    => (string) $order->get_order_number(),
-							'message'   => '' !== $job['message'] ? $job['message'] : __( 'DHL label creation failed.', 'dhl-for-woocommerce' ),
+							'message'   => $failure_message,
 							'purchased' => ! empty( $job['purchased'] ),
+							'category'  => $category,
 							'edit_url'  => $this->get_order_edit_url( $order_id ),
 						);
 					}
@@ -2514,6 +2539,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 						'doneErrors' => esc_html__( 'DHL label creation finished — some orders failed.', 'dhl-for-woocommerce' ),
 						'stalled'    => esc_html__( 'DHL labels are still queued but nothing is processing yet — your site may not be running background tasks. Check WooCommerce → Status → Scheduled Actions, or reload later.', 'dhl-for-woocommerce' ),
 						'failTitle'  => esc_html__( 'Orders that could not be created:', 'dhl-for-woocommerce' ),
+						'catTransient' => esc_html__( 'Temporary connection problem — Retry should clear these.', 'dhl-for-woocommerce' ),
+						'catAction'    => esc_html__( 'Retry alone will not help — open the order, fix the issue, then Retry.', 'dhl-for-woocommerce' ),
 						'purchased'  => esc_html__( 'Some orders may already have a label at DHL — open them and verify before retrying. Retry does not re-create these.', 'dhl-for-woocommerce' ),
 						'error'      => esc_html__( 'Something went wrong. Please reload the page.', 'dhl-for-woocommerce' ),
 					),

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -744,6 +744,24 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		}
 
 		/**
+		 * Appends a plain-language hint to connection/timeout failures so a transient network problem
+		 * reads as "reachability, use Retry" rather than a raw cURL string. Other errors pass through.
+		 *
+		 * @param string $message Raw failure message.
+		 *
+		 * @return string
+		 */
+		protected function humanize_label_error( $message ) {
+			// Connection-level failures (timeouts, DNS, refused, SSL) are almost always transient network
+			// issues rather than bad order data, so point the merchant at Retry instead of a raw cURL string.
+			if ( preg_match( '/cURL error (7|28|35|56)|timed out|timeout|could not resolve host|failed to connect|ssl connection/i', $message ) ) {
+				return $message . ' ' . esc_html__( '(The DHL API could not be reached — usually a temporary network issue; use Retry.)', 'dhl-for-woocommerce' );
+			}
+
+			return $message;
+		}
+
+		/**
 		 * Records a failed background label creation on the order: job state plus an order note.
 		 *
 		 * @param int    $order_id Order ID.
@@ -754,6 +772,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 * @return void
 		 */
 		protected function record_async_label_failure( $order_id, $message, $context = array() ) {
+			$message            = $this->humanize_label_error( $message );
 			$context['message'] = $message;
 			$this->set_label_job_status( $order_id, self::JOB_FAILED, $context );
 

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -19,6 +19,10 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 
 		const DHL_DOWNLOAD_ENDPOINT = 'dhl_download_label';
 
+		// Action Scheduler hook and group used for background label creation.
+		const ACTION_CREATE_LABEL = 'pr_dhl_create_label_async';
+		const ACTION_GROUP        = 'pr-dhl-labels';
+
 		protected $shipping_dhl_settings = array();
 
 		protected $service = 'DHL';
@@ -45,6 +49,9 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			// Order page metabox actions
 			add_action( 'wp_ajax_wc_shipment_dhl_gen_label', array( $this, 'save_meta_box_ajax' ) );
 			add_action( 'wp_ajax_wc_shipment_dhl_delete_label', array( $this, 'delete_label_ajax' ) );
+
+			// Background (Action Scheduler) label-creation callback.
+			add_action( self::ACTION_CREATE_LABEL, array( $this, 'create_label_async' ), 10, 1 );
 
 			// Prevent the DHL tracking number being copied from a subscription to its renewal and resubscribe orders.
 			// Detect the capability rather than a version number: the data copier (and the array-based
@@ -414,6 +421,82 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			do_action( 'pr_shipping_dhl_label_created', $order_id );
 
 			return $label_tracking_info;
+		}
+
+		/**
+		 * Whether WooCommerce Action Scheduler is available for background jobs.
+		 *
+		 * @return bool
+		 */
+		public function is_action_scheduler_available() {
+			return function_exists( 'as_enqueue_async_action' ) && function_exists( 'as_has_scheduled_action' );
+		}
+
+		/**
+		 * Queues background label creation for a single order.
+		 *
+		 * Runs the work in an Action Scheduler job when available, otherwise falls
+		 * back to synchronous execution so the label is still created. A second job
+		 * is not queued while one is already pending for the same order.
+		 *
+		 * @param int $order_id Order ID.
+		 *
+		 * @return bool True if a background job was queued, false if it ran synchronously or was already queued.
+		 */
+		public function schedule_label_creation( $order_id ) {
+			if ( ! $this->is_action_scheduler_available() ) {
+				// Graceful fallback: create the label in the current request.
+				$this->create_label_async( $order_id );
+
+				return false;
+			}
+
+			// Do not queue a second job while one is already pending for this order.
+			if ( as_has_scheduled_action( self::ACTION_CREATE_LABEL, array( $order_id ), self::ACTION_GROUP ) ) {
+				return false;
+			}
+
+			as_enqueue_async_action( self::ACTION_CREATE_LABEL, array( $order_id ), self::ACTION_GROUP );
+
+			return true;
+		}
+
+		/**
+		 * Action Scheduler callback: create a DHL label for one order in the background.
+		 *
+		 * Rebuilds the label args from the stored order data rather than relying on a
+		 * serialized job payload, skips orders that already have a label, and records
+		 * any failure as an order note so it is never silently lost.
+		 *
+		 * @param int $order_id Order ID.
+		 *
+		 * @return void
+		 */
+		public function create_label_async( $order_id ) {
+			// Skip if a label has already been created for this order.
+			if ( ! empty( $this->get_dhl_label_tracking( $order_id ) ) ) {
+				return;
+			}
+
+			try {
+				$this->save_default_dhl_label_items( $order_id );
+
+				$args = $this->get_label_args( $order_id );
+
+				$this->create_dhl_label( $order_id, $args );
+			} catch ( Exception $e ) {
+				$order = wc_get_order( $order_id );
+
+				if ( $order instanceof WC_Order ) {
+					$order->add_order_note(
+						sprintf(
+							/* translators: %s is the error message returned by the DHL API */
+							esc_html__( 'DHL label could not be created: %s', 'dhl-for-woocommerce' ),
+							$e->getMessage()
+						)
+					);
+				}
+			}
 		}
 
 		public function delete_label_ajax() {

--- a/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
+++ b/pr-dhl-woocommerce/includes/abstract-pr-dhl-wc-order.php
@@ -61,6 +61,14 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 			add_action( self::ACTION_CREATE_LABEL, array( $this, 'create_label_async' ), 10, 1 );
 			add_action( self::ACTION_CREATE_LABELS_BATCH, array( $this, 'create_labels_batch_async' ), 10, 3 );
 
+			// Live progress UI for background bulk-label jobs on the Orders screen, and its AJAX endpoints.
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_label_batch_assets' ) );
+			add_action( 'admin_notices', array( $this, 'render_label_batch_progress' ) );
+			add_action( 'wp_ajax_pr_dhl_label_batch_progress', array( $this, 'ajax_label_batch_progress' ) );
+			add_action( 'wp_ajax_pr_dhl_label_batch_download', array( $this, 'ajax_label_batch_download' ) );
+			add_action( 'wp_ajax_pr_dhl_label_batch_retry', array( $this, 'ajax_label_batch_retry' ) );
+			add_action( 'wp_ajax_pr_dhl_label_batch_dismiss', array( $this, 'ajax_label_batch_dismiss' ) );
+
 			// Prevent the DHL tracking number being copied from a subscription to its renewal and resubscribe orders.
 			// Detect the capability rather than a version number: the data copier (and the array-based
 			// wc_subscriptions_{type}_data filters) were introduced together in subscriptions-core 2.5.0.
@@ -560,6 +568,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 				$this->set_label_job_status( $order_id, self::JOB_PENDING );
 			}
 
+			$this->start_label_batch( $pending_orders );
+
 			return array(
 				array(
 					'message' => sprintf(
@@ -603,6 +613,8 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					),
 				);
 			}
+
+			$this->start_label_batch( $pending_orders );
 
 			return array(
 				array(
@@ -1553,14 +1565,25 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		/**
 		 * Bulk functions
 		 */
-		public function add_order_bulk_actions() {
+		/**
+		 * Whether the current admin request is the WooCommerce Orders list screen (HPOS or legacy).
+		 *
+		 * @return bool
+		 */
+		protected function is_orders_list_screen() {
 			global $typenow, $pagenow, $current_screen;
 
-			$is_orders_list = API_Utils::is_HPOS()
-				? ( wc_get_page_screen_id( 'shop-order' ) === $current_screen->id && 'admin.php' === $pagenow )
-				: ( 'shop_order' === $typenow && 'edit.php' === $pagenow );
+			if ( API_Utils::is_HPOS() ) {
+				return isset( $current_screen->id )
+					&& wc_get_page_screen_id( 'shop-order' ) === $current_screen->id
+					&& 'admin.php' === $pagenow;
+			}
 
-			if ( ! $is_orders_list ) {
+			return 'shop_order' === $typenow && 'edit.php' === $pagenow;
+		}
+
+		public function add_order_bulk_actions() {
+			if ( ! $this->is_orders_list_screen() ) {
 				return;
 			}
 
@@ -1931,26 +1954,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 		 */
 		protected function build_merged_label_message( $merge_files ) {
 			try {
-				$file_bulk = $this->merge_label_files( $merge_files );
-
-				if ( ! file_exists( $file_bulk['file_bulk_path'] ) ) {
-					return array(
-						array(
-							'message' => esc_html__( 'Could not create bulk DHL label file, download individually.', 'dhl-for-woocommerce' ),
-							'type'    => 'error',
-						),
-					);
-				}
-
-				// Stash the merged file path for the download endpoint. Expires in 3 minutes: long enough
-				// for the user to see the link and click it.
-				set_transient(
-					'_dhl_bulk_download_labels_file_' . get_current_user_id(),
-					$file_bulk['file_bulk_path'],
-					180
-				);
-
-				$bulk_download_label_url = $this->generate_download_url( '/' . self::DHL_DOWNLOAD_ENDPOINT . '/bulk' );
+				$bulk_download_label_url = $this->prepare_merged_label_download_url( $merge_files );
 
 				return array(
 					array(
@@ -1967,6 +1971,316 @@ if ( ! class_exists( 'PR_DHL_WC_Order' ) ) :
 					),
 				);
 			}
+		}
+
+		/**
+		 * Merges the given label files into one PDF, stashes its path in a short-lived per-user transient
+		 * and returns the URL of the bulk-download endpoint that serves it.
+		 *
+		 * @param array $merge_files Absolute paths of the label files to merge.
+		 *
+		 * @return string The bulk-download URL.
+		 * @throws Exception If the files cannot be merged or the merged file is missing.
+		 */
+		protected function prepare_merged_label_download_url( $merge_files ) {
+			$file_bulk = $this->merge_label_files( $merge_files );
+
+			if ( ! file_exists( $file_bulk['file_bulk_path'] ) ) {
+				throw new Exception( esc_html__( 'Could not create bulk DHL label file, download individually.', 'dhl-for-woocommerce' ) );
+			}
+
+			// Stash the merged file path for the download endpoint. Expires in 3 minutes: long enough
+			// for the user to see the link and click it.
+			set_transient(
+				'_dhl_bulk_download_labels_file_' . get_current_user_id(),
+				$file_bulk['file_bulk_path'],
+				180
+			);
+
+			return $this->generate_download_url( '/' . self::DHL_DOWNLOAD_ENDPOINT . '/bulk' );
+		}
+
+		/**
+		 * Transient key holding the current user's in-flight bulk-label batch (the set of order IDs the
+		 * Orders-screen progress UI polls). Keyed per user so concurrent admins don't see each other's runs.
+		 *
+		 * @return string
+		 */
+		protected function label_batch_key() {
+			return 'pr_dhl_label_batch_' . get_current_user_id();
+		}
+
+		/**
+		 * Starts, or extends, the current user's tracked bulk-label batch. Order IDs from a batch that is
+		 * still running are merged in, so queuing a second selection before the first finishes keeps both
+		 * visible in the same progress bar rather than losing the earlier one.
+		 *
+		 * @param array $order_ids Order IDs just queued.
+		 *
+		 * @return void
+		 */
+		protected function start_label_batch( $order_ids ) {
+			$order_ids = array_map( 'intval', (array) $order_ids );
+
+			// Carry over only orders from a previous batch that are still in flight. A batch left
+			// undismissed after it finished must not bleed its already-created orders into this run
+			// (which would re-count them and re-merge their PDFs on "Download all").
+			$existing = $this->get_label_batch();
+			if ( ! empty( $existing['ids'] ) ) {
+				foreach ( $existing['ids'] as $existing_id ) {
+					if ( self::JOB_PENDING === $this->get_label_job_status( $existing_id )['status'] ) {
+						$order_ids[] = $existing_id;
+					}
+				}
+				$order_ids = array_values( array_unique( $order_ids ) );
+			}
+
+			set_transient( $this->label_batch_key(), array( 'ids' => $order_ids, 'ts' => time() ), DAY_IN_SECONDS );
+		}
+
+		/**
+		 * Returns the current user's tracked bulk-label batch.
+		 *
+		 * @return array Empty array when none is tracked, otherwise array{ids: int[]}.
+		 */
+		protected function get_label_batch() {
+			$batch = get_transient( $this->label_batch_key() );
+
+			if ( ! is_array( $batch ) || empty( $batch['ids'] ) ) {
+				return array();
+			}
+
+			$batch['ids'] = array_map( 'intval', (array) $batch['ids'] );
+
+			return $batch;
+		}
+
+		/**
+		 * Stops tracking the current user's bulk-label batch.
+		 *
+		 * @return void
+		 */
+		protected function clear_label_batch() {
+			delete_transient( $this->label_batch_key() );
+		}
+
+		/**
+		 * Aggregates the per-order job state of the tracked batch for the progress UI.
+		 *
+		 * @return array|null Null when no batch is tracked.
+		 */
+		public function get_label_batch_progress() {
+			$batch = $this->get_label_batch();
+
+			if ( empty( $batch['ids'] ) ) {
+				return null;
+			}
+
+			$created = 0;
+			$failed  = 0;
+			$pending = 0;
+
+			// The background callbacks always record a terminal JOB_CREATED / JOB_FAILED for every queued
+			// order, so the stored job status is authoritative here — no need for a second per-order load
+			// of the label tracking meta.
+			foreach ( $batch['ids'] as $order_id ) {
+				$status = $this->get_label_job_status( $order_id )['status'];
+
+				if ( self::JOB_CREATED === $status ) {
+					++$created;
+				} elseif ( self::JOB_FAILED === $status ) {
+					++$failed;
+				} else {
+					++$pending;
+				}
+			}
+
+			$done       = 0 === $pending;
+			$started_at = isset( $batch['ts'] ) ? (int) $batch['ts'] : 0;
+
+			// If a grace period passes with nothing processed at all, the Action Scheduler queue is
+			// almost certainly not running (no cron / no queue runner). Surface that instead of spinning
+			// forever, so the merchant can act rather than wait indefinitely.
+			$stalled = ! $done
+				&& 0 === ( $created + $failed )
+				&& $started_at > 0
+				&& ( time() - $started_at ) > 120;
+
+			return array(
+				'total'        => count( $batch['ids'] ),
+				'created'      => $created,
+				'failed'       => $failed,
+				'pending'      => $pending,
+				'done'         => $done,
+				'stalled'      => $stalled,
+				'has_failed'   => $failed > 0,
+				'can_download' => $created > 0,
+			);
+		}
+
+		/**
+		 * Shared guard for the batch AJAX endpoints: verifies the nonce and the order-management capability,
+		 * ending the request with a JSON error when either fails.
+		 *
+		 * @return void
+		 */
+		protected function verify_label_batch_request() {
+			check_ajax_referer( 'pr-dhl-label-batch', 'nonce' );
+
+			if ( ! current_user_can( 'edit_shop_orders' ) ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'You are not allowed to manage DHL labels.', 'dhl-for-woocommerce' ) ), 403 );
+			}
+		}
+
+		/**
+		 * AJAX: return the aggregated progress of the current user's bulk-label batch.
+		 *
+		 * @return void
+		 */
+		public function ajax_label_batch_progress() {
+			$this->verify_label_batch_request();
+
+			$progress = $this->get_label_batch_progress();
+
+			if ( null === $progress ) {
+				wp_send_json_success( array( 'active' => false ) );
+			}
+
+			$progress['active'] = true;
+			wp_send_json_success( $progress );
+		}
+
+		/**
+		 * AJAX: merge the labels created so far in the batch into one PDF and return its download URL.
+		 *
+		 * @return void
+		 */
+		public function ajax_label_batch_download() {
+			$this->verify_label_batch_request();
+
+			$batch = $this->get_label_batch();
+
+			if ( empty( $batch['ids'] ) ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'No DHL label batch is in progress.', 'dhl-for-woocommerce' ) ) );
+			}
+
+			$merge_files = array();
+
+			foreach ( $batch['ids'] as $order_id ) {
+				$label_tracking_info = $this->get_dhl_label_tracking( $order_id );
+
+				if ( ! empty( $label_tracking_info['label_path'] ) ) {
+					$merge_files[] = PR_DHL()->resolve_label_file_path( $label_tracking_info['label_path'] );
+				}
+			}
+
+			if ( empty( $merge_files ) ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'There are no created DHL labels to download yet.', 'dhl-for-woocommerce' ) ) );
+			}
+
+			try {
+				wp_send_json_success( array( 'url' => $this->prepare_merged_label_download_url( $merge_files ) ) );
+			} catch ( Exception $e ) {
+				wp_send_json_error( array( 'message' => $e->getMessage() ) );
+			}
+		}
+
+		/**
+		 * AJAX: re-queue the failed orders in the batch (the shared retry path skips any label bought
+		 * at DHL but not saved locally, so a retry never double-charges).
+		 *
+		 * @return void
+		 */
+		public function ajax_label_batch_retry() {
+			$this->verify_label_batch_request();
+
+			$batch = $this->get_label_batch();
+
+			if ( empty( $batch['ids'] ) ) {
+				wp_send_json_error( array( 'message' => esc_html__( 'No DHL label batch is in progress.', 'dhl-for-woocommerce' ) ) );
+			}
+
+			$this->retry_failed_label_jobs( $batch['ids'] );
+
+			wp_send_json_success();
+		}
+
+		/**
+		 * AJAX: stop tracking the batch once the user dismisses the progress panel.
+		 *
+		 * @return void
+		 */
+		public function ajax_label_batch_dismiss() {
+			$this->verify_label_batch_request();
+			$this->clear_label_batch();
+			wp_send_json_success();
+		}
+
+		/**
+		 * Enqueues the Orders-screen progress-bar script when the current user has a batch in flight.
+		 *
+		 * @return void
+		 */
+		public function enqueue_label_batch_assets() {
+			if ( ! $this->is_orders_list_screen() || empty( $this->get_label_batch() ) ) {
+				return;
+			}
+
+			wp_enqueue_script(
+				'pr-dhl-label-batch',
+				PR_DHL_PLUGIN_DIR_URL . '/assets/js/pr-dhl-bulk-progress.js',
+				array( 'jquery' ),
+				PR_DHL_VERSION,
+				true
+			);
+
+			wp_localize_script(
+				'pr-dhl-label-batch',
+				'prDhlLabelBatch',
+				array(
+					'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'pr-dhl-label-batch' ),
+					'interval' => 5000,
+					'i18n'     => array(
+						'creating'   => esc_html__( 'Creating DHL labels in the background…', 'dhl-for-woocommerce' ),
+						/* translators: %1$d created, %2$d failed, %3$d still in progress */
+						'status'     => esc_html__( '%1$d created, %2$d failed, %3$d still in progress', 'dhl-for-woocommerce' ),
+						'doneOk'     => esc_html__( 'All DHL labels created.', 'dhl-for-woocommerce' ),
+						'doneErrors' => esc_html__( 'DHL label creation finished — some orders failed.', 'dhl-for-woocommerce' ),
+						'stalled'    => esc_html__( 'DHL labels are still queued but nothing is processing yet — your site may not be running background tasks. Check WooCommerce → Status → Scheduled Actions, or reload later.', 'dhl-for-woocommerce' ),
+						'error'      => esc_html__( 'Something went wrong. Please reload the page.', 'dhl-for-woocommerce' ),
+					),
+				)
+			);
+		}
+
+		/**
+		 * Renders the (initially hidden) progress panel on the Orders screen; the enqueued script fills and
+		 * updates it by polling ajax_label_batch_progress().
+		 *
+		 * @return void
+		 */
+		public function render_label_batch_progress() {
+			if ( ! $this->is_orders_list_screen() || empty( $this->get_label_batch() ) ) {
+				return;
+			}
+			?>
+			<div id="pr-dhl-label-batch" class="notice notice-info pr-dhl-label-batch" style="display:none;">
+				<p class="pr-dhl-label-batch__title"><strong></strong></p>
+				<div class="pr-dhl-label-batch__bar"><span class="pr-dhl-label-batch__fill"></span></div>
+				<p class="pr-dhl-label-batch__status"></p>
+				<p class="pr-dhl-label-batch__actions" style="display:none;">
+					<a href="#" class="button button-primary pr-dhl-label-batch__download"><?php echo esc_html__( 'Download all labels', 'dhl-for-woocommerce' ); ?></a>
+					<a href="#" class="button pr-dhl-label-batch__retry"><?php echo esc_html__( 'Retry failed', 'dhl-for-woocommerce' ); ?></a>
+					<a href="#" class="button-link pr-dhl-label-batch__dismiss"><?php echo esc_html__( 'Dismiss', 'dhl-for-woocommerce' ); ?></a>
+				</p>
+			</div>
+			<style>
+				.pr-dhl-label-batch__bar{height:14px;max-width:480px;margin:8px 0;background:#e2e4e7;border-radius:7px;overflow:hidden}
+				.pr-dhl-label-batch__fill{display:block;height:100%;width:0;background:#d40511;transition:width .4s ease}
+				.pr-dhl-label-batch__actions .button{margin-right:6px}
+			</style>
+			<?php
 		}
 
 		/**

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
@@ -680,15 +680,8 @@ class PR_DHL_WC_Order_Deutsche_Post extends PR_DHL_WC_Order {
 			// Gather args for DHL API call
 			$args = $this->get_label_args( $order_id );
 
-			// Allow third parties to modify the args to the DHL APIs
-			$args       = apply_filters( 'pr_shipping_dhl_label_args', $args, $order_id );
-			$dhl_obj    = PR_DHL()->get_dhl_factory();
-			$label_info = $dhl_obj->get_dhl_label( $args );
-
-			$this->save_dhl_label_tracking( $order_id, $label_info );
+			$this->create_dhl_label( $order_id, $args );
 			$label_url = $this->get_download_label_url( $order_id );
-
-			do_action( 'pr_shipping_dhl_label_created', $order_id );
 
 			wp_send_json(
 				array(

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-deutsche-post.php
@@ -970,8 +970,10 @@ class PR_DHL_WC_Order_Deutsche_Post extends PR_DHL_WC_Order {
 
 	public function get_bulk_actions() {
 		return array(
-			'pr_dhl_create_labels' => esc_html__( 'Create DHL Label', 'dhl-for-woocommerce' ),
-			'pr_dhl_create_orders' => esc_html__( 'Finalize DHL Waybill', 'dhl-for-woocommerce' ),
+			'pr_dhl_create_labels'       => esc_html__( 'Create DHL Label', 'dhl-for-woocommerce' ),
+			'pr_dhl_retry_failed_labels' => esc_html__( 'Retry Failed DHL Labels', 'dhl-for-woocommerce' ),
+			'pr_dhl_download_labels'     => esc_html__( 'Download DHL Labels', 'dhl-for-woocommerce' ),
+			'pr_dhl_create_orders'       => esc_html__( 'Finalize DHL Waybill', 'dhl-for-woocommerce' ),
 		);
 	}
 

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
@@ -1224,7 +1224,7 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Paket' ) ) :
 			}
 
 			if ( self::JOB_FAILED === $job['status'] ) {
-				$title = '' !== $job['message'] ? $job['message'] : esc_html__( 'DHL label creation failed.', 'dhl-for-woocommerce' );
+				$title = '' !== $job['message'] ? $job['message'] : __( 'DHL label creation failed.', 'dhl-for-woocommerce' );
 
 				return '<span class="dashicons dashicons-warning" title="' . esc_attr( $title ) . '"></span>';
 			}

--- a/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
+++ b/pr-dhl-woocommerce/includes/class-pr-dhl-wc-order-paket.php
@@ -995,9 +995,11 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Paket' ) ) :
 			$shop_manager_actions = array();
 
 			$shop_manager_actions = array(
-				'pr_dhl_create_labels'  => esc_html__( 'DHL Create Labels', 'dhl-for-woocommerce' ),
-				'pr_dhl_delete_labels'  => esc_html__( 'DHL Delete Labels', 'dhl-for-woocommerce' ),
-				'pr_dhl_request_pickup' => esc_html__( 'DHL Request Pickup', 'dhl-for-woocommerce' ),
+				'pr_dhl_create_labels'       => esc_html__( 'DHL Create Labels', 'dhl-for-woocommerce' ),
+				'pr_dhl_retry_failed_labels' => esc_html__( 'DHL Retry Failed Labels', 'dhl-for-woocommerce' ),
+				'pr_dhl_download_labels'     => esc_html__( 'DHL Download Labels', 'dhl-for-woocommerce' ),
+				'pr_dhl_delete_labels'       => esc_html__( 'DHL Delete Labels', 'dhl-for-woocommerce' ),
+				'pr_dhl_request_pickup'      => esc_html__( 'DHL Request Pickup', 'dhl-for-woocommerce' ),
 			);
 
 			return $shop_manager_actions;
@@ -1129,10 +1131,19 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Paket' ) ) :
 
 		public function create_label_on_status_changed( $order_id, $status_from, $status_to, $order ) {
 
-			$status_setting = str_replace( 'wc-', '', $this->shipping_dhl_settings['dhl_create_label_on_status'] );
-			if ( $status_setting == $status_to ) {
-				$this->process_bulk_actions( 'pr_dhl_create_labels', array( $order_id ) );
+			if ( empty( $this->shipping_dhl_settings['dhl_create_label_on_status'] ) ) {
+				return;
 			}
+
+			$status_setting = str_replace( 'wc-', '', $this->shipping_dhl_settings['dhl_create_label_on_status'] );
+			if ( $status_setting !== $status_to ) {
+				return;
+			}
+
+			// Queue the label in the background instead of calling the DHL API inline during the status
+			// change (which, on the checkout-driven transition, blocks the customer's request and swallows
+			// any error). schedule_label_creation() records the outcome as an order note either way.
+			$this->schedule_label_creation( $order_id );
 		}
 
 		protected function get_tracking_link( $order_id ) {
@@ -1202,11 +1213,23 @@ if ( ! class_exists( 'PR_DHL_WC_Order_Paket' ) ) :
 		private function get_print_status( $order_id ) {
 			$label_tracking_info = $this->get_dhl_label_tracking( $order_id );
 
-			if ( empty( $label_tracking_info ) ) {
-				return '<strong>&ndash;</strong>';
-			} else {
+			if ( ! empty( $label_tracking_info ) ) {
 				return '<span class="dashicons dashicons-yes"></span>';
 			}
+
+			$job = $this->get_label_job_status( $order_id );
+
+			if ( self::JOB_PENDING === $job['status'] ) {
+				return '<span class="dashicons dashicons-clock" title="' . esc_attr__( 'DHL label creation queued in the background.', 'dhl-for-woocommerce' ) . '"></span>';
+			}
+
+			if ( self::JOB_FAILED === $job['status'] ) {
+				$title = '' !== $job['message'] ? $job['message'] : esc_html__( 'DHL label creation failed.', 'dhl-for-woocommerce' );
+
+				return '<span class="dashicons dashicons-warning" title="' . esc_attr( $title ) . '"></span>';
+			}
+
+			return '<strong>&ndash;</strong>';
 		}
 
 

--- a/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-paket.php
+++ b/pr-dhl-woocommerce/includes/pr-dhl-api/class-pr-dhl-api-paket.php
@@ -56,7 +56,10 @@ class PR_DHL_API_Paket extends PR_DHL_API {
 	 */
 	public function get_dhl_labels( $multiple_orders_args ) {
 		$items_info = array();
-		$labels     = array();
+		$labels     = array(
+			'labels' => array(),
+			'errors' => array(),
+		);
 		$uom        = get_option( 'woocommerce_weight_unit' );
 
 		foreach ( $multiple_orders_args as $args ) {
@@ -72,22 +75,42 @@ class PR_DHL_API_Paket extends PR_DHL_API {
 			}
 		}
 
-		// Create the item and get the barcode
-		if ( ! empty( $items_info ) ) {
-			$items = $this->dhl_label->api_client->create_items( $items_info );
-			foreach ( $items['items'] as $item ) {
-				$order_id = (int) str_replace( apply_filters( 'pr_shipping_dhl_paket_label_ref_no_prefix', 'order_' ), '', $item->shipmentRefNo );
-				if ( isset( $item->label->b64 ) ) {
-					$file               = $this->dhl_label->save_data_file( 'label', $order_id, $item->label->b64 );
-					$labels['labels'][] = array(
-						'order_id'        => $order_id,
-						'label_path'      => $file['label_path'],
-						'tracking_number' => $item->shipmentNo,
-						'tracking_status' => '',
-					);
-				}
-			}
+		if ( empty( $items_info ) ) {
+			return $labels;
+		}
 
+		// Every shipment is created in a single API request.
+		$items = $this->dhl_label->api_client->create_items( $items_info );
+
+		// A multi-package order returns several shipments under the same order reference.
+		$items_by_order = array();
+		foreach ( $items['items'] as $item ) {
+			$order_id                      = (int) str_replace( apply_filters( 'pr_shipping_dhl_paket_label_ref_no_prefix', 'order_' ), '', $item->shipmentRefNo );
+			$items_by_order[ $order_id ][] = $item;
+		}
+
+		// Reuse the single-label save routines so return labels and customs documents are handled identically.
+		foreach ( $items_by_order as $order_id => $order_items ) {
+			try {
+				if ( count( $order_items ) > 1 ) {
+					$label_tracking_info = $this->dhl_label->save_multiple_shipments( 'label', $order_id, $order_items );
+				} else {
+					$label_tracking_info = $this->dhl_label->save_export_files( 'label', $order_id, $order_items[0] );
+				}
+
+				$label_tracking_info['order_id']        = $order_id;
+				$label_tracking_info['tracking_status'] = '';
+
+				$labels['labels'][] = $label_tracking_info;
+			} catch ( Exception $e ) {
+				$labels['errors'][] = array(
+					'order_id' => $order_id,
+					'message'  => $e->getMessage(),
+				);
+			}
+		}
+
+		if ( ! empty( $items['errors'] ) ) {
 			foreach ( $items['errors'] as $error ) {
 				$labels['errors'][] = array(
 					'order_id' => $error['order_id'],

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -72,6 +72,7 @@ More detailed instructions on how to set up your store and configure it are cons
 * Add: When the background batch finishes, the progress bar lists why each order failed (with links to those orders), lets you download every created label as one merged PDF, and retries the failed orders (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
+* Tweak: Label failures caused by a network or timeout problem now say so and suggest retrying, and the DHL API request timeout can be adjusted with the pr_dhl_api_request_timeout filter.
 
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -73,6 +73,7 @@ More detailed instructions on how to set up your store and configure it are cons
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 * Tweak: Label failures caused by a network or timeout problem now say so and suggest retrying, and the DHL API request timeout can be adjusted with the pr_dhl_api_request_timeout filter.
+* Tweak: Background bulk-label processing is more resilient — progress survives a cache clear, a per-order lock stops concurrent jobs buying a label twice, deleted orders no longer stall a batch, and a stuck queue is detected and reported.
 
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -68,8 +68,8 @@ More detailed instructions on how to set up your store and configure it are cons
 == Changelog ==
 
 = 4.1.0 =
-* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections; each order shows its queued, created or failed status.
-* Add: "DHL Retry Failed Labels" and "DHL Download Labels" bulk actions — retry orders whose label failed and download every created label as one merged PDF.
+* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections, with a live progress bar on the Orders screen showing created, failed and in-progress counts.
+* Add: When the background batch finishes, download every created label as one merged PDF or retry the failed orders directly from the progress bar (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -68,6 +68,9 @@ More detailed instructions on how to set up your store and configure it are cons
 == Changelog ==
 
 = 4.1.0 =
+* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections; each order shows its queued, created or failed status.
+* Add: "DHL Retry Failed Labels" and "DHL Download Labels" bulk actions — retry orders whose label failed and download every created label as one merged PDF.
+* Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 
 = 4.0.1 =

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -68,12 +68,9 @@ More detailed instructions on how to set up your store and configure it are cons
 == Changelog ==
 
 = 4.1.0 =
-* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections, with a live progress bar on the Orders screen showing created, failed and in-progress counts.
-* Add: When the background batch finishes, the progress bar lists why each order failed (with links to those orders), lets you download every created label as one merged PDF, and retries the failed orders (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
-* Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
-* Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
-* Tweak: Label failures caused by a network or timeout problem now say so and suggest retrying, and the DHL API request timeout can be adjusted with the pr_dhl_api_request_timeout filter.
-* Tweak: Background bulk-label processing is more resilient — progress survives a cache clear, a per-order lock stops concurrent jobs buying a label twice, deleted orders no longer stall a batch, and a stuck queue is detected and reported.
+* Add: Bulk DHL label creation now runs in the background, so large selections no longer time out. A live progress bar on the Orders screen shows created, failed and in-progress counts, explains why any order failed, and lets you download all labels as one PDF or retry the failed ones.
+* Fix: Automatic label creation on an order status change no longer runs during the customer's checkout request, and records any failure as an order note instead of failing silently.
+* Tweak: The DHL API request timeout can now be adjusted with the pr_dhl_api_request_timeout filter.
 
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -67,6 +67,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.1.0 =
+* Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
+
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.

--- a/pr-dhl-woocommerce/readme.md
+++ b/pr-dhl-woocommerce/readme.md
@@ -69,7 +69,7 @@ More detailed instructions on how to set up your store and configure it are cons
 
 = 4.1.0 =
 * Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections, with a live progress bar on the Orders screen showing created, failed and in-progress counts.
-* Add: When the background batch finishes, download every created label as one merged PDF or retry the failed orders directly from the progress bar (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
+* Add: When the background batch finishes, the progress bar lists why each order failed (with links to those orders), lets you download every created label as one merged PDF, and retries the failed orders (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -76,8 +76,8 @@ More detailed instructions on how to set up your store and configure it are cons
 == Changelog ==
 
 = 4.1.0 =
-* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections; each order shows its queued, created or failed status.
-* Add: "DHL Retry Failed Labels" and "DHL Download Labels" bulk actions — retry orders whose label failed and download every created label as one merged PDF.
+* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections, with a live progress bar on the Orders screen showing created, failed and in-progress counts.
+* Add: When the background batch finishes, download every created label as one merged PDF or retry the failed orders directly from the progress bar (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -77,7 +77,7 @@ More detailed instructions on how to set up your store and configure it are cons
 
 = 4.1.0 =
 * Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections, with a live progress bar on the Orders screen showing created, failed and in-progress counts.
-* Add: When the background batch finishes, download every created label as one merged PDF or retry the failed orders directly from the progress bar (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
+* Add: When the background batch finishes, the progress bar lists why each order failed (with links to those orders), lets you download every created label as one merged PDF, and retries the failed orders (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -81,6 +81,7 @@ More detailed instructions on how to set up your store and configure it are cons
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 * Tweak: Label failures caused by a network or timeout problem now say so and suggest retrying, and the DHL API request timeout can be adjusted with the pr_dhl_api_request_timeout filter.
+* Tweak: Background bulk-label processing is more resilient — progress survives a cache clear, a per-order lock stops concurrent jobs buying a label twice, deleted orders no longer stall a batch, and a stuck queue is detected and reported.
 
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -75,6 +75,9 @@ More detailed instructions on how to set up your store and configure it are cons
 
 == Changelog ==
 
+= 4.1.0 =
+* Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
+
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.
 * Fix: Store DHL shipping label files in a protected location so they can no longer be downloaded directly through their web address.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -76,6 +76,9 @@ More detailed instructions on how to set up your store and configure it are cons
 == Changelog ==
 
 = 4.1.0 =
+* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections; each order shows its queued, created or failed status.
+* Add: "DHL Retry Failed Labels" and "DHL Download Labels" bulk actions — retry orders whose label failed and download every created label as one merged PDF.
+* Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
 
 = 4.0.1 =

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -80,6 +80,7 @@ More detailed instructions on how to set up your store and configure it are cons
 * Add: When the background batch finishes, the progress bar lists why each order failed (with links to those orders), lets you download every created label as one merged PDF, and retries the failed orders (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
 * Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
 * Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
+* Tweak: Label failures caused by a network or timeout problem now say so and suggest retrying, and the DHL API request timeout can be adjusted with the pr_dhl_api_request_timeout filter.
 
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.

--- a/pr-dhl-woocommerce/readme.txt
+++ b/pr-dhl-woocommerce/readme.txt
@@ -76,12 +76,9 @@ More detailed instructions on how to set up your store and configure it are cons
 == Changelog ==
 
 = 4.1.0 =
-* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections, with a live progress bar on the Orders screen showing created, failed and in-progress counts.
-* Add: When the background batch finishes, the progress bar lists why each order failed (with links to those orders), lets you download every created label as one merged PDF, and retries the failed orders (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
-* Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
-* Fix: Bulk label creation no longer times out on large batches — all selected orders are now created in a single DHL API request.
-* Tweak: Label failures caused by a network or timeout problem now say so and suggest retrying, and the DHL API request timeout can be adjusted with the pr_dhl_api_request_timeout filter.
-* Tweak: Background bulk-label processing is more resilient — progress survives a cache clear, a per-order lock stops concurrent jobs buying a label twice, deleted orders no longer stall a batch, and a stuck queue is detected and reported.
+* Add: Bulk DHL label creation now runs in the background, so large selections no longer time out. A live progress bar on the Orders screen shows created, failed and in-progress counts, explains why any order failed, and lets you download all labels as one PDF or retry the failed ones.
+* Fix: Automatic label creation on an order status change no longer runs during the customer's checkout request, and records any failure as an order note instead of failing silently.
+* Tweak: The DHL API request timeout can now be adjusted with the pr_dhl_api_request_timeout filter.
 
 = 4.0.1 =
 * Fix: Restrict Deutsche Post waybill label downloads to users who can manage orders.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you successfully run tests with your changes locally?

_Cart/checkout items not applicable: admin-side label flow + background-processing infrastructure, no storefront surface._

### Changes proposed in this Pull Request:

ClickUp: https://app.clickup.com/t/868kkyukv (background-processing feature)

Moves DHL label creation to WooCommerce Action Scheduler. Targets the long-lived `feature/label-background-processing` branch (frozen from `master` pending approval). **Includes the merge of `bulk-label-batch-api` (PR #386)**, whose batch method (`get_dhl_labels()`) this feature builds on. This is the single feature PR — the "ST" items below are ClickUp tracking units, not separate PRs. **This PR now covers the whole epic (ST1–ST8).**

**1. Extract the shared per-order label creation**
The `filter → get_dhl_label() → save_dhl_label_tracking() → do_action()` tail, duplicated across the single-order AJAX path, the bulk loop and the Deutsche Post override, is extracted into `create_dhl_label( $order_id, $args )`. Pure refactor.

**2. Action Scheduler infrastructure + graceful fallback**
`is_action_scheduler_available()`, `schedule_label_creation()` (async, or synchronous fallback, deduped), `create_label_async()` (the single-order callback), registered in `init_hooks()`.

**3. Per-order job-state store**
`set_label_job_status()` / `get_label_job_status()` persist `pending` / `created` / `failed` (+ reason + warnings) in order meta.

**4. Bulk creation → chunked background jobs**
- `process_bulk_actions()` returns early into the background path when Action Scheduler is available; otherwise it keeps the existing synchronous batch/per-order path (non-AS hosts unaffected).
- `enqueue_bulk_label_jobs()` skips already-labeled orders, chunks the rest (`pr_dhl_bulk_label_chunk_size`, default 10), enqueues one `pr_dhl_create_labels_batch_async` per chunk, marks each order `pending`, returns a single "N orders queued" notice.
- `create_labels_batch_async()` creates a chunk in one `get_dhl_labels()` request, maps results back per order, updates job-state, and records failures (whole-request, per-order, and unreturned orders) as `failed` + an order note.
- **Idempotency:** already-labeled orders skipped before the request is built; `pending` orders not re-queued; the post-purchase persistence loop is throw-proof so a storage failure never makes Action Scheduler retry and re-buy; a purchased-but-unsaved order gets a distinct "verify before retrying" note.

**5. Progress UI + "Download all" finalizer + "Retry failed"** *(new)*
- **Live progress bar on the Orders screen.** Queuing a bulk batch stores its order IDs in a per-user transient; a bar rendered on the Orders list (`render_label_batch_progress()` + `pr-dhl-bulk-progress.js`) polls `ajax_label_batch_progress()` every 5s and shows *"X created, Y failed, Z in progress"*. When the batch settles it turns green/amber and reveals **Download all labels** and **Retry failed** buttons inline. Failures are listed **grouped by reason with links to the affected orders** (so a systematic cause reads as "10× Invalid postal code" rather than ten mystery failures), and orders whose label was purchased-but-unsaved are called out as *verify manually* and excluded from Retry. If nothing processes within a grace period (no cron / no queue runner) it reports a *stalled* state instead of spinning forever. All four AJAX endpoints are nonce- + `edit_shop_orders`-guarded.
- Order metabox shows a job-status notice via `get_label_job_status_notice()`: "being created in the background" while `pending`, and the failure reason when `failed`.
- The Paket orders-list "DHL Label Created" column now reflects job state — a clock for `pending`, a warning (with the reason as tooltip) for `failed`, the check for `created`.
- New **"DHL Download Labels"** bulk action (`build_bulk_label_download()`): merges the labels already created for the selected orders into one PDF — the same merged-PDF path the progress bar's Download button uses.
- New **"DHL Retry Failed Labels"** bulk action (`retry_failed_label_jobs()`): re-queues only the selected orders whose last job `failed`, and never re-buys a label that was purchased at DHL but failed to save locally (tracked via a `purchased` flag on the job state).

**6. Create-label-on-status → background** *(new, closes "Issue 2")*
`create_label_on_status_changed()` now calls `schedule_label_creation()` instead of running the DHL API call inline in the status-change/checkout request. The label is created in an Action Scheduler job and any failure is recorded as an order note via `record_async_label_failure()` instead of being silently swallowed during checkout.

**7. Deutsche Post parity** *(new)*
The bulk gate enqueues background jobs for non-batch APIs too: batch-capable APIs (Paket) chunk into batched requests, the rest (Deutsche Post, no batch endpoint) run one `pr_dhl_create_label_async` job per order via the new `enqueue_per_order_label_jobs()`. DP's `get_dhl_label()` saves its item barcode itself, so the async path finalizes into a waybill exactly as the synchronous path did. DP also gets the Retry/Download bulk actions.

**8. Changelog / readme** *(new)*
Entries added to both `readme.txt` and `readme.md` under `= 4.1.0 =` for the background processing, the two new bulk actions, and the create-on-status fix.

**Known residual (documented, not a blocker):** a hard PHP fatal or timeout *between* the DHL purchase and the local save — not an exception — could still let Action Scheduler re-run a chunk and re-buy the unsaved orders. Eliminating this last window needs carrier-side idempotency (a DHL idempotency key / reference dedupe); tracked for hardening. Progress is surfaced through WooCommerce-native order screens (status column + metabox notice, reload to refresh) rather than a bespoke auto-polling UI, to keep the surface robust and testable.

### How to test the changes in this Pull Request:

1. Single-order label creation (order metabox → Generate Label) is unchanged.
2. **Bulk (Paket, Action Scheduler present):** select several orders → **DHL Create Labels** → returns immediately with "N orders queued" and a **live progress bar** appears on the Orders list, updating every 5s; jobs appear under WooCommerce → Status → Scheduled Actions (group `pr-dhl-labels`). When the bar completes it shows **Download all labels** / **Retry failed**. The orders column also shows a clock while pending and a check once created.
3. **Re-run** the bulk action on the same orders → already-labeled orders skipped (no duplicate labels/jobs).
4. **Force failures** (bad address on some orders) → those show job status `failed` with a matching order note and a warning icon (reason in tooltip); the rest still succeed. Select the failed ones → **DHL Retry Failed Labels** → only those re-queue.
5. **Download all:** after a batch completes, select the created orders → **DHL Download Labels** → one merged PDF download link.
6. **Create-label-on-status:** set Settings → the "create label on status" status, move an order to it → no API call runs in the request; a background job creates the label, and a forced failure lands as an order note (no silent failure at checkout).
7. **Deutsche Post:** bulk **Create DHL Label** → per-order background jobs; once created, **Finalize DHL Waybill** works as before.
8. **Non-Action-Scheduler context:** confirm the bulk action still creates labels synchronously (existing batch path).

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

* Add: Bulk DHL label creation now runs in the background via WooCommerce Action Scheduler, removing request timeouts on large selections, with a live progress bar on the Orders screen showing created, failed and in-progress counts.
* Add: When the background batch finishes, download every created label as one merged PDF or retry the failed orders directly from the progress bar (also available as the "DHL Download Labels" and "DHL Retry Failed Labels" bulk actions).
* Fix: Automatic label creation on an order status change no longer blocks the customer's checkout request and now records any failure as an order note instead of failing silently.
